### PR TITLE
fix: getFilesNameForTables for empty table name

### DIFF
--- a/meerkat-dbm/src/utils/__tests__/is-defined.spec.ts
+++ b/meerkat-dbm/src/utils/__tests__/is-defined.spec.ts
@@ -1,0 +1,11 @@
+import { isDefined } from '../is-defined';
+
+describe('isDefined', () => {
+  test('should return false if value is undefined', () => {
+    expect(isDefined(undefined)).toBe(false);
+  });
+
+  test('should return true if value is defined', () => {
+    expect(isDefined('defined')).toBe(true);
+  });
+});

--- a/meerkat-dbm/src/utils/index.ts
+++ b/meerkat-dbm/src/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './get-buffer-from-json';
+export * from './is-defined';
 export * from './merge-file-buffer-store-into-table';
+

--- a/meerkat-dbm/src/utils/is-defined.ts
+++ b/meerkat-dbm/src/utils/is-defined.ts
@@ -1,0 +1,3 @@
+export const isDefined = <T>(value: T | undefined): value is T => {
+  return value !== undefined;
+};


### PR DESCRIPTION
Fix: Remove default table name in getFilesNameForTables

no-work-item
