### PR TITLE
feat: Add join path support

### DIFF
--- a/meerkat-browser/src/browser-cube-to-sql/browser-cube-to-sql.ts
+++ b/meerkat-browser/src/browser-cube-to-sql/browser-cube-to-sql.ts
@@ -102,7 +102,10 @@ export const cubeQueryToSQL = async (
     })
   );
 
-  const updatedTableSchema = await getCombinedTableSchema(updatedTableSchemas);
+  const updatedTableSchema = await getCombinedTableSchema(
+    updatedTableSchemas,
+    cubeQuery
+  );
 
   const ast = cubeToDuckdbAST(cubeQuery, updatedTableSchema);
   if (!ast) {

--- a/meerkat-core/src/types/cube-types/query.ts
+++ b/meerkat-core/src/types/cube-types/query.ts
@@ -80,7 +80,7 @@ type QueryOrderType = 'asc' | 'desc';
  */
 type ApiScopes = 'graphql' | 'meta' | 'data' | 'jobs';
 
-export type FilterType = 'BASE_FILTER' | 'PROJECTION_FILTER'
+export type FilterType = 'BASE_FILTER' | 'PROJECTION_FILTER';
 
 interface QueryFilter {
   member: Member;
@@ -112,16 +112,58 @@ interface QueryTimeDimension {
 }
 
 /**
+ * Join Edge data type.
+ */
+
+interface JoinEdge {
+  /**
+   * Left node.
+   */
+  left: Member;
+
+  /**
+   * Right node.
+   */
+  right: Member;
+
+  /**
+   * On condition.
+   */
+  on: string;
+
+  /**
+   * Example
+   * [
+   *  [
+   *    {
+   *      left:  dim_ticket,
+   *      right: dim_user
+   *      on: 'created_by_id'
+   *    },
+   *   {
+   *     left : dim_user,
+   *     right: dim_user_role,
+   *     on: 'role_id'
+   *   }
+   *  ]
+   * ]
+   *
+   *
+   */
+}
+
+/**
  * Incoming network query data type.
  */
 
-type MeerkatQueryFilter = (QueryFilter | LogicalAndFilter | LogicalOrFilter)
+type MeerkatQueryFilter = QueryFilter | LogicalAndFilter | LogicalOrFilter;
 
 interface Query {
   measures: Member[];
   dimensions?: (Member | TimeMember)[];
   filters?: MeerkatQueryFilter[];
   timeDimensions?: QueryTimeDimension[];
+  joinPath?: JoinEdge[][];
   segments?: Member[];
   limit?: null | number;
   offset?: number;
@@ -150,13 +192,15 @@ interface NormalizedQuery extends Query {
   order?: [{ id: string; desc: boolean }];
 }
 
-
-
 export {
   ApiScopes,
   ApiType,
-  FilterOperator, LogicalAndFilter,
-  LogicalOrFilter, MeerkatQueryFilter, Member,
+  FilterOperator,
+  JoinEdge,
+  LogicalAndFilter,
+  LogicalOrFilter,
+  MeerkatQueryFilter,
+  Member,
   MemberType,
   NormalizedQuery,
   NormalizedQueryFilter,
@@ -168,6 +212,5 @@ export {
   QueryType,
   RequestType,
   ResultType,
-  TimeMember
+  TimeMember,
 };
-

--- a/meerkat-core/src/utils/get-possible-nodes.spec.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.spec.ts
@@ -1,0 +1,195 @@
+import { getNestedTableSchema } from './get-possible-nodes';
+describe('Table schema functions', () => {
+  it('Test', () => {
+    const tableSchema = [
+      {
+        name: 'node1',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node1.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node1',
+        joins: [
+          { sql: 'node1.id = node2.id' },
+          { sql: 'node1.id = node3.id' },
+          { sql: 'node1.id = node6.id' },
+        ],
+      },
+      {
+        name: 'node2',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node2.id',
+          },
+          {
+            name: 'node11_id',
+            sql: 'node2.node11_id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node2',
+        joins: [
+          { sql: 'node2.id = node4.id' },
+          { sql: 'node2.node11_id = node11.id' },
+        ],
+      },
+      {
+        name: 'node3',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node3.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node3',
+        joins: [{ sql: 'node3.id = node5.id' }],
+      },
+      {
+        name: 'node4',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node4.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node4',
+        joins: [
+          { sql: 'node4.id = node5.id' },
+          { sql: 'node4.id = node6.id' },
+          { sql: 'node4.id = node7.id' },
+        ],
+      },
+      {
+        name: 'node5',
+        measures: [],
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node5.id',
+          },
+        ],
+        sql: 'select * from node5',
+        joins: [{ sql: 'node5.id = node8.id' }],
+      },
+      {
+        name: 'node6',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node6.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node6',
+        joins: [{ sql: 'node6.id = node9.id' }],
+      },
+      {
+        name: 'node7',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node7.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node7',
+        joins: [{ sql: 'node7.id = node10.id' }],
+      },
+      {
+        name: 'node8',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node8.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node8',
+        joins: [],
+      },
+      {
+        name: 'node9',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node9.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node9',
+        joins: [{ sql: 'node9.id = node10.id' }],
+      },
+      {
+        name: 'node10',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node10.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node10',
+        joins: [],
+      },
+      {
+        name: 'node11',
+        dimensions: [
+          {
+            name: 'id',
+            sql: 'node11.id',
+          },
+        ],
+        measures: [],
+        sql: 'select * from node11',
+        joins: [],
+      },
+    ];
+
+    const complexJoinPath = [
+      [
+        {
+          left: 'node1',
+          right: 'node2',
+          on: 'id',
+        },
+        {
+          left: 'node2',
+          right: 'node4',
+          on: 'id',
+        },
+        {
+          left: 'node4',
+          right: 'node7',
+          on: 'id',
+        },
+      ],
+      [
+        {
+          left: 'node1',
+          right: 'node3',
+          on: 'id',
+        },
+      ],
+      [
+        {
+          left: 'node1',
+          right: 'node2',
+          on: 'id',
+        },
+        {
+          left: 'node2',
+          right: 'node11',
+          on: 'node11_id',
+        },
+      ],
+    ];
+    ``;
+    getNestedTableSchema(tableSchema, complexJoinPath);
+  });
+});

--- a/meerkat-core/src/utils/get-possible-nodes.spec.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.spec.ts
@@ -1,6 +1,6 @@
 import { getNestedTableSchema } from './get-possible-nodes';
 describe('Table schema functions', () => {
-  it('Test', () => {
+  it('Test', async () => {
     const tableSchema = [
       {
         name: 'node1',
@@ -190,6 +190,167 @@ describe('Table schema functions', () => {
       ],
     ];
     ``;
-    getNestedTableSchema(tableSchema, complexJoinPath);
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      complexJoinPath
+    );
+    expect(nestedSchema).toEqual(expectedOutput);
   });
 });
+
+const expectedOutput = {
+  name: 'node1',
+  measures: [],
+  dimensions: [
+    {
+      schema: {
+        name: 'id',
+        sql: 'node1.id',
+      },
+      children: [
+        {
+          name: 'node2',
+          measures: [],
+          dimensions: [
+            {
+              schema: {
+                name: 'id',
+                sql: 'node2.id',
+              },
+              children: [
+                {
+                  name: 'node4',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node4.id',
+                      },
+                      children: [
+                        {
+                          name: 'node7',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node7.id',
+                              },
+                              children: [
+                                {
+                                  name: 'node10',
+                                  measures: [],
+                                  dimensions: [
+                                    {
+                                      schema: {
+                                        name: 'id',
+                                        sql: 'node10.id',
+                                      },
+                                      children: [],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          name: 'node5',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node5.id',
+                              },
+                              children: [],
+                            },
+                          ],
+                        },
+                        {
+                          name: 'node6',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node6.id',
+                              },
+                              children: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              schema: {
+                name: 'node11_id',
+                sql: 'node2.node11_id',
+              },
+              children: [
+                {
+                  name: 'node11',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node11.id',
+                      },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'node3',
+          measures: [],
+          dimensions: [
+            {
+              schema: {
+                name: 'id',
+                sql: 'node3.id',
+              },
+              children: [
+                {
+                  name: 'node5',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node5.id',
+                      },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'node6',
+          measures: [],
+          dimensions: [
+            {
+              schema: {
+                name: 'id',
+                sql: 'node6.id',
+              },
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -1,5 +1,3 @@
-import path = require('path');
-import fs = require('fs');
 import { Graph, checkLoopInGraph, createDirectedGraph } from '../joins/joins';
 import { Dimension, JoinEdge, Measure, TableSchema } from '../types/cube-types';
 
@@ -24,7 +22,7 @@ export const getNestedTableSchema = async (
   joinPath: JoinEdge[][]
 ) => {
   const tableSchemaSqlMap: { [key: string]: string } = {};
-  for (let schema of tableSchemas) {
+  for (const schema of tableSchemas) {
     if (!schema) {
       throw new Error('Schema is undefined');
     }
@@ -86,7 +84,7 @@ export const getNestedTableSchema = async (
     // Mark the path as checked
     checkedPaths[pathKey] = true;
 
-    let nestedRightSchema: NestedTableSchema = {
+    const nestedRightSchema: NestedTableSchema = {
       name: rightSchema.name,
       measures: (rightSchema.measures || []).map(
         (measure) => ({ schema: measure, children: [] } as NestedMeasure)
@@ -151,7 +149,7 @@ const getNextPossibleNodes = (
       return;
     }
 
-    for (let [node] of Object.entries(nextPossibleNodes)) {
+    for (const [node] of Object.entries(nextPossibleNodes)) {
       const nextSchema = tableSchemas.find(
         (schema) => schema.name === node
       ) as TableSchema;
@@ -160,7 +158,7 @@ const getNextPossibleNodes = (
         throw new Error(`The schema for ${node} does not exist.`);
       }
 
-      for (let children of dimension.children || []) {
+      for (const children of dimension.children || []) {
         getNextPossibleNodes(
           directedGraph,
           children,

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -1,0 +1,200 @@
+import path = require('path');
+import { Graph, checkLoopInGraph, createDirectedGraph } from '../joins/joins';
+import { Dimension, JoinEdge, Measure, TableSchema } from '../types/cube-types';
+
+export interface NestedMeasure extends Measure {
+  children?: NestedTableSchema[];
+}
+
+export interface NestedDimension extends Dimension {
+  children?: NestedTableSchema[];
+}
+
+export interface NestedTableSchema {
+  name: string;
+  measures: NestedMeasure[];
+  dimensions: NestedDimension[];
+}
+
+export const getNestedTableSchema = async (
+  tableSchemas: TableSchema[],
+  joinPath: JoinEdge[][]
+) => {
+  const tableSchemaSqlMap: { [key: string]: string } = {};
+  for (let schema of tableSchemas) {
+    console.info(tableSchemaSqlMap);
+    if (!schema) {
+      throw new Error('Schema is undefined');
+    }
+    tableSchemaSqlMap[schema.name] = schema.sql;
+  }
+
+  const directedGraph = createDirectedGraph(tableSchemas, tableSchemaSqlMap);
+  const hasLoop = checkLoopInGraph(directedGraph);
+  if (hasLoop) {
+    throw new Error('A loop was detected in the joins.');
+  }
+  const visitedNodes: { [key: string]: boolean } = {};
+
+  const startingNode = tableSchemas.find(
+    (schema) => schema.name === joinPath[0][0].left
+  ) as TableSchema;
+
+  visitedNodes[startingNode.name] = true;
+
+  const nestedTableSchema: NestedTableSchema = {
+    name: startingNode.name,
+    measures: startingNode.measures.map((measure) => ({
+      ...measure,
+      children: [],
+    })),
+    dimensions: startingNode.dimensions.map((dimension) => ({
+      ...dimension,
+      children: [],
+    })),
+  };
+
+  const checkedPaths: { [key: string]: boolean } = {};
+
+  const buildNestedSchema = (
+    edges: JoinEdge[],
+    index: number,
+    nestedTableSchema: NestedTableSchema,
+    tableSchemas: TableSchema[]
+  ): NestedTableSchema => {
+    const edge = edges[index];
+    // If the path has been checked before, return the nested schema immediately
+    const pathKey = `${edge.left}-${edge.right}-${edge.on}`;
+    if (checkedPaths[pathKey]) {
+      nestedTableSchema.dimensions.map((dimension) => {
+        dimension.children?.forEach((child) => {
+          if (child.name === edge.right) {
+            return buildNestedSchema(edges, index + 1, child, tableSchemas);
+          }
+        });
+      });
+      return nestedTableSchema;
+    }
+
+    const rightSchema = tableSchemas.find(
+      (schema) => schema.name === edge.right
+    ) as TableSchema;
+
+    // Mark the path as checked
+    checkedPaths[pathKey] = true;
+
+    let nestedRightSchema: NestedTableSchema = {
+      name: rightSchema.name,
+      measures: (rightSchema.measures || []).map(
+        (measure) => ({ ...measure, children: [] } as NestedMeasure)
+      ),
+      dimensions: (rightSchema.dimensions || []).map(
+        (dimension) => ({ ...dimension, children: [] } as NestedDimension)
+      ),
+    };
+
+    const nestedDimension = nestedTableSchema.dimensions.find(
+      (dimension) => dimension.name === edge.on
+    ) as NestedMeasure;
+
+    if (!nestedDimension) {
+      throw new Error(
+        `The dimension ${edge.on} does not exist in the table schema.`
+      );
+    }
+
+    nestedDimension.children?.push(nestedRightSchema);
+
+    // Mark the right schema as visited
+    visitedNodes[rightSchema.name] = true;
+
+    if (index < edges.length - 1) {
+      buildNestedSchema(
+        edges,
+        index + 1,
+        nestedRightSchema as NestedTableSchema,
+        tableSchemas
+      );
+    }
+    return nestedTableSchema;
+  };
+
+  for (let i = 0; i < joinPath.length; i++) {
+    console.info(nestedTableSchema);
+    buildNestedSchema(joinPath[i], 0, nestedTableSchema, tableSchemas);
+  }
+
+  getNextPossibleNodes(
+    directedGraph,
+    nestedTableSchema,
+    visitedNodes,
+    tableSchemas
+  );
+
+  getNextPossibleNodes(
+    directedGraph,
+    nestedTableSchema,
+    visitedNodes,
+    tableSchemas
+  );
+
+  console.log(JSON.stringify(nestedTableSchema, null, 2));
+
+  return nestedTableSchema;
+};
+
+const getNextPossibleNodes = (
+  directedGraph: Graph,
+  nestedTableSchema: NestedTableSchema,
+  visitedNodes: { [key: string]: boolean },
+  tableSchemas: TableSchema[]
+) => {
+  const currentNode = nestedTableSchema.name;
+
+  for (let i = 0; i < nestedTableSchema.dimensions.length; i++) {
+    const dimension = nestedTableSchema.dimensions[i];
+    const dimensionName = dimension.name;
+    const nextPossibleNodes = directedGraph[currentNode];
+
+    if (!nextPossibleNodes) {
+      return;
+    }
+
+    for (let [node, edge_on] of Object.entries(nextPossibleNodes)) {
+      if (visitedNodes[node]) {
+        continue;
+      }
+      const nextSchema = tableSchemas.find(
+        (schema) => schema.name === node
+      ) as TableSchema;
+
+      if (!nextSchema) {
+        throw new Error(`The schema for ${node} does not exist.`);
+      }
+
+      for (let children of dimension.children || []) {
+        getNextPossibleNodes(
+          directedGraph,
+          children,
+          visitedNodes,
+          tableSchemas
+        );
+      }
+      for (let key in edge_on) {
+        const nestedNextSchema: NestedTableSchema = {
+          name: nextSchema.name,
+          measures: nextSchema.measures.map((measure) => ({
+            ...measure,
+            children: [],
+          })),
+          dimensions: nextSchema.dimensions.map((dimension) => ({
+            ...dimension,
+            children: [],
+          })),
+        };
+
+        dimension.children?.push(nestedNextSchema);
+      }
+    }
+  }
+};

--- a/meerkat-node/src/__tests__/joins.spec.ts
+++ b/meerkat-node/src/__tests__/joins.spec.ts
@@ -299,6 +299,23 @@ describe('Joins Tests', () => {
     BOOK_SCHEMA.joins = [];
     const query = {
       measures: ['books.total_book_count', 'authors.total_author_count'],
+      joinPath: [
+        [
+          {
+            left: 'authors',
+            right: 'books',
+            on: 'author_id',
+          },
+        ],
+        [
+          {
+            left: 'customers',
+            right: 'orders',
+            on: 'customer_id',
+          },
+        ],
+      ],
+
       filters: [],
       dimensions: ['customers.customer_id', 'orders.customer_id'],
     };
@@ -309,7 +326,9 @@ describe('Joins Tests', () => {
         ORDER_SCHEMA,
         AUTHOR_SCHEMA,
       ])
-    ).rejects.toThrow('Multiple starting nodes found in the graph.');
+    ).rejects.toThrow(
+      'Invalid path, starting node is not the same for all paths.'
+    );
   });
 
   it('Three tables join - Direct', async () => {
@@ -323,6 +342,20 @@ describe('Joins Tests', () => {
 
     const query = {
       measures: ['orders.total_order_amount'],
+      joinPath: [
+        [
+          {
+            left: 'customers',
+            right: 'orders',
+            on: 'customer_id',
+          },
+          {
+            left: 'orders',
+            right: 'products',
+            on: 'product_id',
+          },
+        ],
+      ],
       filters: [
         {
           and: [
@@ -366,6 +399,22 @@ describe('Joins Tests', () => {
 
     const query = {
       measures: ['orders.total_order_amount'],
+      joinPath: [
+        [
+          {
+            left: 'customers',
+            right: 'orders',
+            on: 'customer_id',
+          },
+        ],
+        [
+          {
+            left: 'customers',
+            right: 'products',
+            on: 'customer_id',
+          },
+        ],
+      ],
       filters: [
         {
           and: [
@@ -407,6 +456,15 @@ describe('Joins Tests', () => {
   it('Success Join with filters', async () => {
     const query = {
       measures: ['orders.total_order_amount'],
+      joinPath: [
+        [
+          {
+            left: 'customers',
+            right: 'orders',
+            on: 'customer_id',
+          },
+        ],
+      ],
       filters: [
         {
           and: [

--- a/meerkat-node/src/__tests__/joins.spec.ts
+++ b/meerkat-node/src/__tests__/joins.spec.ts
@@ -4,6 +4,7 @@ import { duckdbExec } from '../duckdb-exec';
 export const CREATE_CUTOMERS_TABLE = `
 CREATE TABLE customers (
     customer_id VARCHAR,
+    order_id VARCHAR,
     customer_name VARCHAR,
     customer_email VARCHAR,
     customer_phone VARCHAR
@@ -12,9 +13,9 @@ CREATE TABLE customers (
 
 export const INPUT_CUSTOMERS_DATA = `
 INSERT INTO customers VALUES
-('1', 'John Doe', 'johndoe@gmail.com', '1234567890'),
-('2', 'Jane Doe', 'janedoe@gmail.com', '9876543210'),
-('3', 'John Smith', 'johnsmith@gmail.com', '1234567892'); 
+('1', '3', 'John Doe', 'johndoe@gmail.com', '1234567890'),
+('2', '2', 'Jane Doe', 'janedoe@gmail.com', '9876543210'),
+('3', '1', 'John Smith', 'johnsmith@gmail.com', '1234567892'); 
 `;
 
 export const CUSTOMER_SCHEMA = {
@@ -31,6 +32,11 @@ export const CUSTOMER_SCHEMA = {
     {
       name: 'customer_id',
       sql: 'customers.customer_id',
+      type: 'number',
+    },
+    {
+      name: 'order_id',
+      sql: 'customers.order_id',
       type: 'number',
     },
     {
@@ -52,6 +58,9 @@ export const CUSTOMER_SCHEMA = {
   joins: [
     {
       sql: 'orders.customer_id = customers.customer_id',
+    },
+    {
+      sql: 'orders.order_id = customers.order_id',
     },
   ],
 };
@@ -451,6 +460,96 @@ describe('Joins Tests', () => {
     expect(parsedOutput[0].products__product_id).toBe('1');
     expect(parsedOutput[0].orders__product_id).toBe('2');
     expect(parsedOutput[0].orders__total_order_amount).toBe(80);
+  });
+
+  it('Joins with Different Paths', async () => {
+    const query1 = {
+      measures: ['orders.total_order_amount'],
+      joinPath: [
+        [
+          {
+            left: 'customers',
+            right: 'orders',
+            on: 'customer_id',
+          },
+        ],
+      ],
+      filters: [
+        {
+          and: [
+            {
+              member: 'orders.order_amount',
+              operator: 'gt',
+              values: ['40'],
+            },
+            {
+              member: 'customers.customer_name',
+              operator: 'contains',
+              values: ['Doe'],
+            },
+          ],
+        },
+      ],
+      dimensions: [
+        'orders.product_id',
+        'customers.customer_id',
+        'customers.order_id',
+      ],
+    };
+
+    const sql = await cubeQueryToSQL(query1, [ORDER_SCHEMA, CUSTOMER_SCHEMA]);
+    console.info(`SQL for Simple Cube Query: `, sql);
+    const output = await duckdbExec(sql);
+    const parsedOutput = JSON.parse(JSON.stringify(output));
+    console.info('parsedOutput', parsedOutput);
+    expect(parsedOutput).toHaveLength(3);
+    expect(parsedOutput[0].customers__customer_id).toBe('2');
+    expect(parsedOutput[1].customers__customer_id).toBe('1');
+    expect(parsedOutput[2].customers__customer_id).toBe('1');
+    expect(parsedOutput[0].customers__order_id).toBe('2');
+    expect(parsedOutput[1].customers__order_id).toBe('3');
+    expect(parsedOutput[2].customers__order_id).toBe('3');
+
+    const query2 = {
+      measures: ['orders.total_order_amount'],
+      joinPath: [
+        [
+          {
+            left: 'customers',
+            right: 'orders',
+            on: 'order_id',
+          },
+        ],
+      ],
+      filters: [
+        {
+          and: [
+            {
+              member: 'orders.order_amount',
+              operator: 'gt',
+              values: ['40'],
+            },
+            {
+              member: 'customers.customer_name',
+              operator: 'contains',
+              values: ['Doe'],
+            },
+          ],
+        },
+      ],
+      dimensions: [
+        'orders.product_id',
+        'customers.customer_id',
+        'customers.order_id',
+      ],
+    };
+
+    const sql2 = await cubeQueryToSQL(query2, [ORDER_SCHEMA, CUSTOMER_SCHEMA]);
+    const output2 = await duckdbExec(sql2);
+    const parsedOutput2 = JSON.parse(JSON.stringify(output2));
+    expect(parsedOutput2).toHaveLength(1);
+    expect(parsedOutput2[0].customers__customer_id).toBe('2');
+    expect(parsedOutput2[0].customers__order_id).toBe('2');
   });
 
   it('Success Join with filters', async () => {

--- a/meerkat-node/src/cube-to-sql/cube-to-sql.ts
+++ b/meerkat-node/src/cube-to-sql/cube-to-sql.ts
@@ -90,7 +90,10 @@ export const cubeQueryToSQL = async (
     })
   );
 
-  const updatedTableSchema = await getCombinedTableSchema(updatedTableSchemas);
+  const updatedTableSchema = await getCombinedTableSchema(
+    updatedTableSchemas,
+    cubeQuery
+  );
 
   const ast = cubeToDuckdbAST(cubeQuery, updatedTableSchema);
   if (!ast) {


### PR DESCRIPTION
This PR introduces a significant functionality enhancement with the addition of the `joinPath` support in queries and improved management of nested table schemas within a directed graph. Here's a detailed overview of the changes:

1. **Join Path Support**:  The `joinPath` attribute is a crucial addition to the queries. It is an array of `JoinEdge` objects. Each `JoinEdge` represents a join operation between two tables(`left` and `right`) based on a specific column (`on`). 

The structure of `JoinEdge` is as follows:
```
interface JoinEdge {
  left: Member;  // Left node
  right: Member; // Right node
  on: string;    // On condition
}
```
This specification allows for complex join paths in the queries, enabling users to execute sophisticated queries across multiple tables.

2. **Nested Table Schema Management**: Nested table schema management has been improved with added support for measures, dimensions, and schemas within a directed graph. This is achieved by introducing `NestedMeasure`, `NestedDimension`, and `NestedTableSchema` interfaces. 

The `getNestedTableSchema` function is a significant addition in this regard. It traverses the join paths, checking for loops or undefined schemas in the graph, and maintaining a record of visited nodes.

The `getNextPossibleNodes` function deep traverses the graph nodes, identifying the next possible nodes from the current one while accounting for nested table schemas. 

These enhancements provide a more robust and flexible system, enabling complex operations and queries. Please provide your inputs and suggestions on these changes.