### PR TITLE
Enhancing Graph Traversal in `getNestedTableSchema` with Depth-Limit 

### DIFF
--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "dependencies": {
     "@swc/helpers": "~0.5.0"
   },

--- a/meerkat-core/src/index.ts
+++ b/meerkat-core/src/index.ts
@@ -14,5 +14,6 @@ export { FilterType } from './types/cube-types';
 export * from './types/cube-types/index';
 export * from './types/duckdb-serialization-types/index';
 export { BASE_TABLE_NAME } from './utils/base-ast';
+export * from './utils/get-possible-nodes';
 export { meerkatPlaceholderReplacer } from './utils/meerkat-placeholder-replacer';
 export { memberKeyToSafeKey } from './utils/member-key-to-safe-key';

--- a/meerkat-core/src/utils/get-possible-nodes.spec.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.spec.ts
@@ -1,204 +1,775 @@
 import { getNestedTableSchema } from './get-possible-nodes';
+
 describe('Table schema functions', () => {
-  it('Test', async () => {
-    const tableSchema = [
+  const tableSchema = [
+    {
+      name: 'node1',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node1.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node1',
+      joins: [
+        { sql: 'node1.id = node2.id' },
+        { sql: 'node1.id = node3.id' },
+        { sql: 'node1.id = node6.id' },
+      ],
+    },
+    {
+      name: 'node2',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node2.id',
+        },
+        {
+          name: 'node11_id',
+          sql: 'node2.node11_id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node2',
+      joins: [
+        { sql: 'node2.id = node4.id' },
+        { sql: 'node2.node11_id = node11.id' },
+      ],
+    },
+    {
+      name: 'node3',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node3.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node3',
+      joins: [{ sql: 'node3.id = node5.id' }],
+    },
+    {
+      name: 'node4',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node4.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node4',
+      joins: [
+        { sql: 'node4.id = node5.id' },
+        { sql: 'node4.id = node6.id' },
+        { sql: 'node4.id = node7.id' },
+      ],
+    },
+    {
+      name: 'node5',
+      measures: [],
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node5.id',
+        },
+      ],
+      sql: 'select * from node5',
+      joins: [{ sql: 'node5.id = node8.id' }],
+    },
+    {
+      name: 'node6',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node6.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node6',
+      joins: [{ sql: 'node6.id = node9.id' }],
+    },
+    {
+      name: 'node7',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node7.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node7',
+      joins: [{ sql: 'node7.id = node10.id' }],
+    },
+    {
+      name: 'node8',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node8.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node8',
+      joins: [],
+    },
+    {
+      name: 'node9',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node9.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node9',
+      joins: [{ sql: 'node9.id = node10.id' }],
+    },
+    {
+      name: 'node10',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node10.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node10',
+      joins: [],
+    },
+    {
+      name: 'node11',
+      dimensions: [
+        {
+          name: 'id',
+          sql: 'node11.id',
+        },
+      ],
+      measures: [],
+      sql: 'select * from node11',
+      joins: [],
+    },
+  ];
+
+  const basicJoinPath = [
+    [
       {
-        name: 'node1',
-        dimensions: [
-          {
+        left: 'node1',
+        right: 'node2',
+        on: 'id',
+      },
+    ],
+  ];
+
+  const intermediateJoinPath = [
+    [
+      {
+        left: 'node1',
+        right: 'node2',
+        on: 'id',
+      },
+      {
+        left: 'node2',
+        right: 'node4',
+        on: 'id',
+      },
+    ],
+    [
+      {
+        left: 'node1',
+        right: 'node3',
+        on: 'id',
+      },
+    ],
+  ];
+
+  const complexJoinPath = [
+    [
+      {
+        left: 'node1',
+        right: 'node2',
+        on: 'id',
+      },
+      {
+        left: 'node2',
+        right: 'node4',
+        on: 'id',
+      },
+      {
+        left: 'node4',
+        right: 'node7',
+        on: 'id',
+      },
+    ],
+    [
+      {
+        left: 'node1',
+        right: 'node3',
+        on: 'id',
+      },
+    ],
+    [
+      {
+        left: 'node1',
+        right: 'node2',
+        on: 'id',
+      },
+      {
+        left: 'node2',
+        right: 'node11',
+        on: 'node11_id',
+      },
+    ],
+  ];
+
+  it('Test basic join path with depth 0 (should return original graph)', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      basicJoinPath,
+      0
+    );
+
+    expect(nestedSchema).toEqual({
+      name: 'node1',
+      measures: [],
+      dimensions: [
+        {
+          schema: {
             name: 'id',
             sql: 'node1.id',
           },
-        ],
-        measures: [],
-        sql: 'select * from node1',
-        joins: [
-          { sql: 'node1.id = node2.id' },
-          { sql: 'node1.id = node3.id' },
-          { sql: 'node1.id = node6.id' },
-        ],
-      },
-      {
-        name: 'node2',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node2.id',
-          },
-          {
-            name: 'node11_id',
-            sql: 'node2.node11_id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node2',
-        joins: [
-          { sql: 'node2.id = node4.id' },
-          { sql: 'node2.node11_id = node11.id' },
-        ],
-      },
-      {
-        name: 'node3',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node3.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node3',
-        joins: [{ sql: 'node3.id = node5.id' }],
-      },
-      {
-        name: 'node4',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node4.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node4',
-        joins: [
-          { sql: 'node4.id = node5.id' },
-          { sql: 'node4.id = node6.id' },
-          { sql: 'node4.id = node7.id' },
-        ],
-      },
-      {
-        name: 'node5',
-        measures: [],
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node5.id',
-          },
-        ],
-        sql: 'select * from node5',
-        joins: [{ sql: 'node5.id = node8.id' }],
-      },
-      {
-        name: 'node6',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node6.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node6',
-        joins: [{ sql: 'node6.id = node9.id' }],
-      },
-      {
-        name: 'node7',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node7.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node7',
-        joins: [{ sql: 'node7.id = node10.id' }],
-      },
-      {
-        name: 'node8',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node8.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node8',
-        joins: [],
-      },
-      {
-        name: 'node9',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node9.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node9',
-        joins: [{ sql: 'node9.id = node10.id' }],
-      },
-      {
-        name: 'node10',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node10.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node10',
-        joins: [],
-      },
-      {
-        name: 'node11',
-        dimensions: [
-          {
-            name: 'id',
-            sql: 'node11.id',
-          },
-        ],
-        measures: [],
-        sql: 'select * from node11',
-        joins: [],
-      },
-    ];
+          children: [
+            {
+              name: 'node2',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node2.id',
+                  },
+                  children: [],
+                },
+                {
+                  schema: {
+                    name: 'node11_id',
+                    sql: 'node2.node11_id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
 
-    const complexJoinPath = [
-      [
-        {
-          left: 'node1',
-          right: 'node2',
-          on: 'id',
-        },
-        {
-          left: 'node2',
-          right: 'node4',
-          on: 'id',
-        },
-        {
-          left: 'node4',
-          right: 'node7',
-          on: 'id',
-        },
-      ],
-      [
-        {
-          left: 'node1',
-          right: 'node3',
-          on: 'id',
-        },
-      ],
-      [
-        {
-          left: 'node1',
-          right: 'node2',
-          on: 'id',
-        },
-        {
-          left: 'node2',
-          right: 'node11',
-          on: 'node11_id',
-        },
-      ],
-    ];
-    ``;
+  it('Test basic join path with depth 1', async () => {
     const nestedSchema = await getNestedTableSchema(
       tableSchema,
-      complexJoinPath
+      basicJoinPath,
+      1
     );
-    expect(nestedSchema).toEqual(expectedOutput);
+
+    expect(nestedSchema).toEqual({
+      name: 'node1',
+      measures: [],
+      dimensions: [
+        {
+          schema: {
+            name: 'id',
+            sql: 'node1.id',
+          },
+          children: [
+            {
+              name: 'node2',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node2.id',
+                  },
+                  children: [
+                    {
+                      name: 'node4',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node4.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  schema: {
+                    name: 'node11_id',
+                    sql: 'node2.node11_id',
+                  },
+                  children: [
+                    {
+                      name: 'node11',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node11.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'node3',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node3.id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'node6',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node6.id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('Test basic join path with depth 2', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      basicJoinPath,
+      2
+    );
+
+    expect(nestedSchema).toEqual({
+      name: 'node1',
+      measures: [],
+      dimensions: [
+        {
+          schema: {
+            name: 'id',
+            sql: 'node1.id',
+          },
+          children: [
+            {
+              name: 'node2',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node2.id',
+                  },
+                  children: [
+                    {
+                      name: 'node4',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node4.id',
+                          },
+                          children: [
+                            {
+                              name: 'node5',
+                              measures: [],
+                              dimensions: [
+                                {
+                                  schema: {
+                                    name: 'id',
+                                    sql: 'node5.id',
+                                  },
+                                  children: [],
+                                },
+                              ],
+                            },
+                            {
+                              name: 'node6',
+                              measures: [],
+                              dimensions: [
+                                {
+                                  schema: {
+                                    name: 'id',
+                                    sql: 'node6.id',
+                                  },
+                                  children: [],
+                                },
+                              ],
+                            },
+                            {
+                              name: 'node7',
+                              measures: [],
+                              dimensions: [
+                                {
+                                  schema: {
+                                    name: 'id',
+                                    sql: 'node7.id',
+                                  },
+                                  children: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  schema: {
+                    name: 'node11_id',
+                    sql: 'node2.node11_id',
+                  },
+                  children: [
+                    {
+                      name: 'node11',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node11.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'node3',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node3.id',
+                  },
+                  children: [
+                    {
+                      name: 'node5',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node5.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'node6',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node6.id',
+                  },
+                  children: [
+                    {
+                      name: 'node9',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node9.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('Test intermediate join path with depth 0 (should return original graph)', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      intermediateJoinPath,
+      0
+    );
+
+    expect(nestedSchema).toEqual({
+      name: 'node1',
+      measures: [],
+      dimensions: [
+        {
+          schema: {
+            name: 'id',
+            sql: 'node1.id',
+          },
+          children: [
+            {
+              name: 'node2',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node2.id',
+                  },
+                  children: [
+                    {
+                      name: 'node4',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node4.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  schema: {
+                    name: 'node11_id',
+                    sql: 'node2.node11_id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'node3',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node3.id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('Test intermediate join path with depth 1', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      intermediateJoinPath,
+      1
+    );
+
+    expect(nestedSchema).toEqual({
+      name: 'node1',
+      measures: [],
+      dimensions: [
+        {
+          schema: {
+            name: 'id',
+            sql: 'node1.id',
+          },
+          children: [
+            {
+              name: 'node2',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node2.id',
+                  },
+                  children: [
+                    {
+                      name: 'node4',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node4.id',
+                          },
+                          children: [
+                            {
+                              name: 'node5',
+                              measures: [],
+                              dimensions: [
+                                {
+                                  schema: {
+                                    name: 'id',
+                                    sql: 'node5.id',
+                                  },
+                                  children: [],
+                                },
+                              ],
+                            },
+                            {
+                              name: 'node6',
+                              measures: [],
+                              dimensions: [
+                                {
+                                  schema: {
+                                    name: 'id',
+                                    sql: 'node6.id',
+                                  },
+                                  children: [],
+                                },
+                              ],
+                            },
+                            {
+                              name: 'node7',
+                              measures: [],
+                              dimensions: [
+                                {
+                                  schema: {
+                                    name: 'id',
+                                    sql: 'node7.id',
+                                  },
+                                  children: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  schema: {
+                    name: 'node11_id',
+                    sql: 'node2.node11_id',
+                  },
+                  children: [
+                    {
+                      name: 'node11',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node11.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'node3',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node3.id',
+                  },
+                  children: [
+                    {
+                      name: 'node5',
+                      measures: [],
+                      dimensions: [
+                        {
+                          schema: {
+                            name: 'id',
+                            sql: 'node5.id',
+                          },
+                          children: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'node6',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node6.id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('Test complex join path with depth 1', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      complexJoinPath,
+      1
+    );
+
+    expect(nestedSchema).toEqual(expectedOutputWithOneDepth);
+  });
+
+  it('Test complex complex join path with depth 2', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      complexJoinPath,
+      2
+    );
+
+    expect(nestedSchema).toEqual(expectedOutputWithTwoDepth);
   });
 });
 
-const expectedOutput = {
+const expectedOutputWithOneDepth = {
   name: 'node1',
   measures: [],
   dimensions: [
@@ -347,6 +918,219 @@ const expectedOutput = {
                 sql: 'node6.id',
               },
               children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const expectedOutputWithTwoDepth = {
+  name: 'node1',
+  measures: [],
+  dimensions: [
+    {
+      schema: {
+        name: 'id',
+        sql: 'node1.id',
+      },
+      children: [
+        {
+          name: 'node2',
+          measures: [],
+          dimensions: [
+            {
+              schema: {
+                name: 'id',
+                sql: 'node2.id',
+              },
+              children: [
+                {
+                  name: 'node4',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node4.id',
+                      },
+                      children: [
+                        {
+                          name: 'node7',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node7.id',
+                              },
+                              children: [
+                                {
+                                  name: 'node10',
+                                  measures: [],
+                                  dimensions: [
+                                    {
+                                      schema: {
+                                        name: 'id',
+                                        sql: 'node10.id',
+                                      },
+                                      children: [],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          name: 'node5',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node5.id',
+                              },
+                              children: [
+                                {
+                                  name: 'node8',
+                                  measures: [],
+                                  dimensions: [
+                                    {
+                                      schema: {
+                                        name: 'id',
+                                        sql: 'node8.id',
+                                      },
+                                      children: [],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          name: 'node6',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node6.id',
+                              },
+                              children: [
+                                {
+                                  name: 'node9',
+                                  measures: [],
+                                  dimensions: [
+                                    {
+                                      schema: {
+                                        name: 'id',
+                                        sql: 'node9.id',
+                                      },
+                                      children: [],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              schema: {
+                name: 'node11_id',
+                sql: 'node2.node11_id',
+              },
+              children: [
+                {
+                  name: 'node11',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node11.id',
+                      },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'node3',
+          measures: [],
+          dimensions: [
+            {
+              schema: {
+                name: 'id',
+                sql: 'node3.id',
+              },
+              children: [
+                {
+                  name: 'node5',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node5.id',
+                      },
+                      children: [
+                        {
+                          name: 'node8',
+                          measures: [],
+                          dimensions: [
+                            {
+                              schema: {
+                                name: 'id',
+                                sql: 'node8.id',
+                              },
+                              children: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'node6',
+          measures: [],
+          dimensions: [
+            {
+              schema: {
+                name: 'id',
+                sql: 'node6.id',
+              },
+              children: [
+                {
+                  name: 'node9',
+                  measures: [],
+                  dimensions: [
+                    {
+                      schema: {
+                        name: 'id',
+                        sql: 'node9.id',
+                      },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -125,8 +125,6 @@ export const getNestedTableSchema = (
     buildNestedSchema(joinPath[i], 0, nestedTableSchema, tableSchemas);
   }
 
-  console.log(visitedNodes, 'visitedNodes');
-
   getNextPossibleNodes(
     directedGraph,
     nestedTableSchema,
@@ -208,13 +206,6 @@ const getNextPossibleNodes = (
         if (visitedNodes[children.name] && currentDepth > 0) {
           continue;
         }
-
-        console.log(
-          'going into recusion with',
-          children.name,
-          'and depth ',
-          visitedNodes[children.name] ? 0 : currentDepth + 1
-        );
 
         getNextPossibleNodes(
           directedGraph,

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -142,7 +142,7 @@ const getNextPossibleNodes = (
   visitedNodes: { [key: string]: boolean },
   tableSchemas: TableSchema[],
   depth: number,
-  currentDepth: number = 0
+  currentDepth = 0
 ) => {
   const currentNode = nestedTableSchema.name;
 


### PR DESCRIPTION
This PR aims to refine the graph traversal process in the `getNestedTableSchema` function by introducing a depth-limit and refining data-fetching effectiveness while working with extensive schemas.

## Crucial Modifications:

1. **Depth Parameter Addition**: In the `getNestedTableSchema` function, the `depth` parameter has been introduced to specify the graph traversal's limit. `depth` serves as a guiding factor determining how far the function travels through the nested schema while generating it.

2. **Depth Implementation in `getNextPossibleNodes` function**: Depth control has been implemented in the `getNextPossibleNodes` function to facilitate fetching the next set of potential nodes considering the determined depth level. 

3. **Current Depth Tracking**: A counter `currentDepth` has been introduced and utilized within the `getNextPossibleNodes` function to maintain real-time tracking of the traversal depth. This ensures an accurate location reference during traversal.

4. **Conditional Halt at Reached Depth**: To optimize traversal, a condition was embedded to discontinue the traversal when `currentDepth` matches the desired `depth`, aborting further unnecessary traversal.

5. **Depth-Level Handling of Schema Existence**: An error message is invoked when a dimension is not present in the schema on the right side of an edge. This ensures the nested schema's complete and accurate construction by validating the dimension availability.

The above described function was also exported for use.