### PR TITLE
Add handling for single node

### DIFF
--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "dependencies": {
     "@swc/helpers": "~0.5.0"
   },

--- a/meerkat-core/src/joins/joins.spec.ts
+++ b/meerkat-core/src/joins/joins.spec.ts
@@ -87,7 +87,7 @@ describe('Table schema functions', () => {
   });
 
   it('should correctly generate a SQL query from the provided join path, table schema SQL map, and directed graph', () => {
-    const joinPath = [
+    const joinPaths = [
       [
         { left: 'table1', right: 'table2', on: 'id' },
         { left: 'table2', right: 'table3', on: 'id' },
@@ -103,7 +103,7 @@ describe('Table schema functions', () => {
       table3: 'select * from table3',
     };
     const sqlQuery = generateSqlQuery(
-      joinPath,
+      joinPaths,
       tableSchemaSqlMap,
       directedGraph
     );

--- a/meerkat-core/src/joins/joins.ts
+++ b/meerkat-core/src/joins/joins.ts
@@ -1,11 +1,11 @@
-import { JoinEdge, Query, TableSchema } from '../types/cube-types';
+import { JoinPath, Query, TableSchema, isJoinNode } from '../types/cube-types';
 
 export type Graph = {
   [key: string]: { [key: string]: { [key: string]: string } };
 };
 
 export function generateSqlQuery(
-  path: JoinEdge[][],
+  path: JoinPath[],
   tableSchemaSqlMap: { [key: string]: string },
   directedGraph: Graph
 ): string {
@@ -18,7 +18,11 @@ export function generateSqlQuery(
   const startingNode = path[0][0].left;
   let query = `${tableSchemaSqlMap[startingNode]}`;
 
-  if (!path[0][0].right) {
+  /**
+   * If the starting node is not a join node, then return the query as is.
+   * It means that the query is a single node query.
+   */
+  if (!isJoinNode(path[0][0])) {
     return query;
   }
 
@@ -32,6 +36,11 @@ export function generateSqlQuery(
     }
     for (let j = 0; j < path[i].length; j++) {
       const currentEdge = path[i][j];
+
+      if (!isJoinNode(currentEdge)) {
+        continue;
+      }
+
       const visitedFrom = visitedNodes.get(currentEdge.right);
 
       // If node is already visited from the same edge, continue to next iteration
@@ -203,7 +212,7 @@ export const getCombinedTableSchema = async (
   console.log('directedGraph', directedGraph);
 
   const baseSql = generateSqlQuery(
-    cubeQuery.joinPath || [],
+    cubeQuery.joinPaths || [],
     tableSchemaSqlMap,
     directedGraph
   );

--- a/meerkat-core/src/joins/joins.ts
+++ b/meerkat-core/src/joins/joins.ts
@@ -57,12 +57,10 @@ export function generateSqlQuery(
       // If visitedFrom is undefined, this is the first visit to the node
       visitedNodes.set(currentEdge.right, currentEdge);
 
-      query += ` LEFT JOIN (${
-        tableSchemaSqlMap[currentEdge.right as string]
-      }) AS ${currentEdge.right}  ON ${
-        directedGraph[currentEdge.left][currentEdge.right as string][
-          currentEdge.on
-        ]
+      query += ` LEFT JOIN (${tableSchemaSqlMap[currentEdge.right]}) AS ${
+        currentEdge.right
+      }  ON ${
+        directedGraph[currentEdge.left][currentEdge.right][currentEdge.on]
       }`;
     }
   }
@@ -208,8 +206,6 @@ export const getCombinedTableSchema = async (
   if (hasLoop) {
     throw new Error('A loop was detected in the joins.');
   }
-
-  console.log('directedGraph', directedGraph);
 
   const baseSql = generateSqlQuery(
     cubeQuery.joinPaths || [],

--- a/meerkat-core/src/joins/joins.ts
+++ b/meerkat-core/src/joins/joins.ts
@@ -18,6 +18,10 @@ export function generateSqlQuery(
   const startingNode = path[0][0].left;
   let query = `${tableSchemaSqlMap[startingNode]}`;
 
+  if (!path[0][0].right) {
+    return query;
+  }
+
   const visitedNodes = new Map();
 
   for (let i = 0; i < path.length; i++) {
@@ -44,10 +48,12 @@ export function generateSqlQuery(
       // If visitedFrom is undefined, this is the first visit to the node
       visitedNodes.set(currentEdge.right, currentEdge);
 
-      query += ` LEFT JOIN (${tableSchemaSqlMap[currentEdge.right]}) AS ${
-        currentEdge.right
-      }  ON ${
-        directedGraph[currentEdge.left][currentEdge.right][currentEdge.on]
+      query += ` LEFT JOIN (${
+        tableSchemaSqlMap[currentEdge.right as string]
+      }) AS ${currentEdge.right}  ON ${
+        directedGraph[currentEdge.left][currentEdge.right as string][
+          currentEdge.on
+        ]
       }`;
     }
   }

--- a/meerkat-core/src/types/cube-types/query.ts
+++ b/meerkat-core/src/types/cube-types/query.ts
@@ -123,8 +123,9 @@ interface JoinEdge {
 
   /**
    * Right node.
+   * If right node is not defined, then there is only one node in the path.
    */
-  right: Member;
+  right?: Member;
 
   /**
    * On condition.

--- a/meerkat-core/src/types/cube-types/query.ts
+++ b/meerkat-core/src/types/cube-types/query.ts
@@ -115,7 +115,7 @@ interface QueryTimeDimension {
  * Join Edge data type.
  */
 
-interface JoinEdge {
+interface JoinNode {
   /**
    * Left node.
    */
@@ -123,9 +123,8 @@ interface JoinEdge {
 
   /**
    * Right node.
-   * If right node is not defined, then there is only one node in the path.
    */
-  right?: Member;
+  right: Member;
 
   /**
    * On condition.
@@ -154,6 +153,23 @@ interface JoinEdge {
 }
 
 /**
+ * Single node data type.
+ * This is the case when there is no join. Just a single node.
+ */
+interface SingleNode {
+  /**
+   * Left node.
+   */
+  left: Member;
+}
+
+type JoinPath = [JoinNode | SingleNode, ...JoinNode[]];
+
+export const isJoinNode = (node: JoinNode | SingleNode): node is JoinNode => {
+  return 'right' in node;
+};
+
+/**
  * Incoming network query data type.
  */
 
@@ -164,7 +180,7 @@ interface Query {
   dimensions?: (Member | TimeMember)[];
   filters?: MeerkatQueryFilter[];
   timeDimensions?: QueryTimeDimension[];
-  joinPath?: JoinEdge[][];
+  joinPaths?: JoinPath[];
   segments?: Member[];
   limit?: null | number;
   offset?: number;
@@ -197,7 +213,7 @@ export {
   ApiScopes,
   ApiType,
   FilterOperator,
-  JoinEdge,
+  JoinPath,
   LogicalAndFilter,
   LogicalOrFilter,
   MeerkatQueryFilter,

--- a/meerkat-core/src/utils/get-possible-nodes.spec.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.spec.ts
@@ -161,6 +161,16 @@ describe('Table schema functions', () => {
     ],
   ];
 
+  const singleNodeJoinPath = [
+    [
+      {
+        left: 'node1',
+        right: '',
+        on: '',
+      },
+    ],
+  ];
+
   const intermediateJoinPath = [
     [
       {
@@ -221,6 +231,75 @@ describe('Table schema functions', () => {
       },
     ],
   ];
+
+  it('Test single node join path', async () => {
+    const nestedSchema = await getNestedTableSchema(
+      tableSchema,
+      singleNodeJoinPath,
+      1
+    );
+
+    expect(nestedSchema).toEqual({
+      name: 'node1',
+      measures: [],
+      dimensions: [
+        {
+          schema: {
+            name: 'id',
+            sql: 'node1.id',
+          },
+          children: [
+            {
+              name: 'node2',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node2.id',
+                  },
+                  children: [],
+                },
+                {
+                  schema: {
+                    name: 'node11_id',
+                    sql: 'node2.node11_id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'node3',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node3.id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+            {
+              name: 'node6',
+              measures: [],
+              dimensions: [
+                {
+                  schema: {
+                    name: 'id',
+                    sql: 'node6.id',
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
 
   it('Test basic join path with depth 0 (should return original graph)', async () => {
     const nestedSchema = await getNestedTableSchema(

--- a/meerkat-core/src/utils/get-possible-nodes.spec.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.spec.ts
@@ -165,8 +165,6 @@ describe('Table schema functions', () => {
     [
       {
         left: 'node1',
-        right: '',
-        on: '',
       },
     ],
   ];

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -64,6 +64,16 @@ export const getNestedTableSchema = (
     tableSchemas: TableSchema[]
   ): NestedTableSchema => {
     const edge = edges[index];
+
+    /**
+     * If there is no right table, return the nested schema immediately
+     * This means there is a single node in the path.
+     */
+
+    if (edge.right === '') {
+      return nestedTableSchema;
+    }
+
     // If the path has been checked before, return the nested schema immediately
     const pathKey = `${edge.left}-${edge.right}-${edge.on}`;
     if (checkedPaths[pathKey]) {
@@ -81,6 +91,10 @@ export const getNestedTableSchema = (
     const rightSchema = tableSchemas.find(
       (schema) => schema.name === edge.right
     ) as TableSchema;
+
+    if (!rightSchema) {
+      throw new Error(`The schema for ${edge.right} does not exist.`);
+    }
 
     // Mark the path as checked
     checkedPaths[pathKey] = true;

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -1,5 +1,11 @@
 import { Graph, checkLoopInGraph, createDirectedGraph } from '../joins/joins';
-import { Dimension, JoinEdge, Measure, TableSchema } from '../types/cube-types';
+import {
+  Dimension,
+  JoinPath,
+  Measure,
+  TableSchema,
+  isJoinNode,
+} from '../types/cube-types';
 
 export interface NestedMeasure {
   schema: Measure;
@@ -19,7 +25,7 @@ export interface NestedTableSchema {
 
 export const getNestedTableSchema = (
   tableSchemas: TableSchema[],
-  joinPath: JoinEdge[][],
+  joinPath: JoinPath[],
   depth: number
 ) => {
   const tableSchemaSqlMap: { [key: string]: string } = {};
@@ -58,7 +64,7 @@ export const getNestedTableSchema = (
   const checkedPaths: { [key: string]: boolean } = {};
 
   const buildNestedSchema = (
-    edges: JoinEdge[],
+    edges: JoinPath,
     index: number,
     nestedTableSchema: NestedTableSchema,
     tableSchemas: TableSchema[]
@@ -70,7 +76,7 @@ export const getNestedTableSchema = (
      * This means there is a single node in the path.
      */
 
-    if (!edge.right) {
+    if (!isJoinNode(edge)) {
       return nestedTableSchema;
     }
 

--- a/meerkat-core/src/utils/get-possible-nodes.ts
+++ b/meerkat-core/src/utils/get-possible-nodes.ts
@@ -70,7 +70,7 @@ export const getNestedTableSchema = (
      * This means there is a single node in the path.
      */
 
-    if (edge.right === '') {
+    if (!edge.right) {
       return nestedTableSchema;
     }
 

--- a/meerkat-node/src/__tests__/joins.spec.ts
+++ b/meerkat-node/src/__tests__/joins.spec.ts
@@ -308,7 +308,7 @@ describe('Joins Tests', () => {
     BOOK_SCHEMA.joins = [];
     const query = {
       measures: ['books.total_book_count', 'authors.total_author_count'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'authors',
@@ -345,7 +345,7 @@ describe('Joins Tests', () => {
       measures: [],
       filters: [],
       dimensions: ['orders.order_id'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'orders',
@@ -376,7 +376,7 @@ describe('Joins Tests', () => {
 
     const query = {
       measures: ['orders.total_order_amount'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'customers',
@@ -433,7 +433,7 @@ describe('Joins Tests', () => {
 
     const query = {
       measures: ['orders.total_order_amount'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'customers',
@@ -490,7 +490,7 @@ describe('Joins Tests', () => {
   it('Joins with Different Paths', async () => {
     const query1 = {
       measures: ['orders.total_order_amount'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'customers',
@@ -537,7 +537,7 @@ describe('Joins Tests', () => {
 
     const query2 = {
       measures: ['orders.total_order_amount'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'customers',
@@ -580,7 +580,7 @@ describe('Joins Tests', () => {
   it('Success Join with filters', async () => {
     const query = {
       measures: ['orders.total_order_amount'],
-      joinPath: [
+      joinPaths: [
         [
           {
             left: 'customers',

--- a/meerkat-node/src/__tests__/joins.spec.ts
+++ b/meerkat-node/src/__tests__/joins.spec.ts
@@ -340,6 +340,31 @@ describe('Joins Tests', () => {
     );
   });
 
+  it('Single node in the path', async () => {
+    const query = {
+      measures: [],
+      filters: [],
+      dimensions: ['orders.order_id'],
+      joinPath: [
+        [
+          {
+            left: 'orders',
+            on: 'order_id',
+          },
+        ],
+      ],
+    };
+    const sql = await cubeQueryToSQL(query, [AUTHOR_SCHEMA, ORDER_SCHEMA]);
+    console.info(`SQL for Simple Cube Query: `, sql);
+    const output = await duckdbExec(sql);
+    const parsedOutput = JSON.parse(JSON.stringify(output));
+    console.info('parsedOutput', parsedOutput);
+    expect(sql).toEqual(
+      'SELECT  orders__order_id FROM (SELECT *, orders.order_id AS orders__order_id FROM (select * from orders) AS orders) AS MEERKAT_GENERATED_TABLE GROUP BY orders__order_id'
+    );
+    expect(parsedOutput).toHaveLength(11);
+  });
+
   it('Three tables join - Direct', async () => {
     const DEMO_SCHEMA = structuredClone(ORDER_SCHEMA);
 


### PR DESCRIPTION
This PR introduces a new addition to the edge case handling in our function. We have added a check for the `edge.right` table. If it's an empty string, indicating no right table is present, the nested schema is returned immediately. This signifies that there's a single node in the path. This change streamlines our code and handles instances where our schema might differ from the standard two-node path.