### PR TITLE
chore: Convert Cube to table schema

### DIFF
--- a/meerkat-browser/src/index.ts
+++ b/meerkat-browser/src/index.ts
@@ -1,1 +1,3 @@
 export * from './browser-cube-to-sql/browser-cube-to-sql';
+export { convertCubeStringToTableSchema };
+import { convertCubeStringToTableSchema } from '@devrev/meerkat-core';

--- a/meerkat-core/src/index.ts
+++ b/meerkat-core/src/index.ts
@@ -14,6 +14,7 @@ export { FilterType } from './types/cube-types';
 export * from './types/cube-types/index';
 export * from './types/duckdb-serialization-types/index';
 export { BASE_TABLE_NAME } from './utils/base-ast';
+export * from './utils/cube-to-table-schema';
 export * from './utils/get-possible-nodes';
 export { meerkatPlaceholderReplacer } from './utils/meerkat-placeholder-replacer';
 export { memberKeyToSafeKey } from './utils/member-key-to-safe-key';

--- a/meerkat-core/src/utils/cube-to-table-schema.spec.ts
+++ b/meerkat-core/src/utils/cube-to-table-schema.spec.ts
@@ -1,0 +1,47 @@
+import { convertCubeToTableSchema } from './cube-to-table-schema';
+describe('cube-to-table-schema', () => {
+  it('Should convert to table schema', async () => {
+    const files = [
+      'cube(`users`, { sql_table: `public.users`, joins: {}, dimensions: { id: { sql: `id`, type: `number`, primary_key: true }, gender: { sql: `gender`, type: `string` }, city: { sql: `city`, type: `string` }, state: { sql: `state`, type: `string` }, first_name: { sql: `first_name`, type: `string` }, company: { sql: `company`, type: `string` }, last_name: { sql: `last_name`, type: `string` }, created_at: { sql: `created_at`, type: `time` } }, measures: { count: { type: `count` } }, pre_aggregations: {} });',
+      'cube(`line_items`, { sql_table: `public.line_items`, joins: { orders: { sql: `${CUBE}.order_id = ${orders}.id`, relationship: `many_to_one` }, products: { sql: `${CUBE}.product_id = ${products}.id`, relationship: `many_to_one` } }, dimensions: { id: { sql: `id`, type: `number`, primary_key: true }, created_at: { sql: `created_at`, type: `time` } }, measures: { count: { type: `count` }, price: { sql: `price`, type: `sum` }, quantity: { sql: `quantity`, type: `sum` } }, pre_aggregations: {} });',
+    ];
+    const outputTableSchemas = [
+      {
+        name: 'users',
+        sql: 'public.users',
+        measures: [{ name: 'count', sql: 'COUNT(*)', type: 'number' }],
+        dimensions: [
+          { name: 'id', sql: 'id', type: 'number' },
+          { name: 'gender', sql: 'gender', type: 'string' },
+          { name: 'city', sql: 'city', type: 'string' },
+          { name: 'state', sql: 'state', type: 'string' },
+          { name: 'first_name', sql: 'first_name', type: 'string' },
+          { name: 'company', sql: 'company', type: 'string' },
+          { name: 'last_name', sql: 'last_name', type: 'string' },
+          { name: 'created_at', sql: 'created_at', type: 'time' },
+        ],
+      },
+      {
+        name: 'line_items',
+        sql: 'public.line_items',
+        measures: [
+          { name: 'count', sql: 'COUNT(*)', type: 'number' },
+          { name: 'price', sql: 'SUM(price)', type: 'number' },
+          { name: 'quantity', sql: 'SUM(quantity)', type: 'number' },
+        ],
+        dimensions: [
+          { name: 'id', sql: 'id', type: 'number' },
+          { name: 'created_at', sql: 'created_at', type: 'time' },
+        ],
+        joins: [
+          { sql: 'MEERKAT.order_id = orders.id' },
+          { sql: 'MEERKAT.product_id = products.id' },
+        ],
+      },
+    ];
+    for (let i = 0; i < files.length; i++) {
+      const tableSchema = convertCubeToTableSchema(files[i]);
+      expect(tableSchema).toEqual(outputTableSchemas[i]);
+    }
+  });
+});

--- a/meerkat-core/src/utils/cube-to-table-schema.spec.ts
+++ b/meerkat-core/src/utils/cube-to-table-schema.spec.ts
@@ -1,4 +1,4 @@
-import { convertCubeToTableSchema } from './cube-to-table-schema';
+import { convertCubeStringToTableSchema } from './cube-to-table-schema';
 describe('cube-to-table-schema', () => {
   it('Should convert to table schema', async () => {
     const files = [
@@ -34,13 +34,13 @@ describe('cube-to-table-schema', () => {
           { name: 'created_at', sql: 'created_at', type: 'time' },
         ],
         joins: [
-          { sql: 'MEERKAT.order_id = orders.id' },
-          { sql: 'MEERKAT.product_id = products.id' },
+          { sql: '{MEERKAT}.order_id = orders.id' },
+          { sql: '{MEERKAT}.product_id = products.id' },
         ],
       },
     ];
     for (let i = 0; i < files.length; i++) {
-      const tableSchema = convertCubeToTableSchema(files[i]);
+      const tableSchema = convertCubeStringToTableSchema(files[i]);
       expect(tableSchema).toEqual(outputTableSchemas[i]);
     }
   });

--- a/meerkat-core/src/utils/cube-to-table-schema.ts
+++ b/meerkat-core/src/utils/cube-to-table-schema.ts
@@ -1,0 +1,81 @@
+import { TableSchema } from '@devrev/meerkat-core';
+
+export function convertCubeToTableSchema(file: string): TableSchema | null {
+  const cube = (name: any, object: any) => ({ name, object });
+  let replacedFile = file.replace(/\${(.*?)}/g, (match, variable) => variable);
+  replacedFile = replacedFile.replace(/CUBE/g, 'MEERKAT');
+  const { name, object } = eval(replacedFile);
+  const resObj: TableSchema = {
+    name,
+    sql: object.sql_table,
+    measures: [],
+    dimensions: [],
+  };
+  const dimensions = object.dimensions;
+  const measures = object.measures;
+  for (const key in dimensions) {
+    resObj.dimensions.push({
+      name: key,
+      sql: dimensions[key].sql,
+      type: dimensions[key].type,
+    });
+  }
+  for (const key in measures) {
+    resObj.measures.push({ name: key, ...convertMeasure(measures[key]) });
+  }
+  if (object.joins && Object.keys(object.joins).length > 0) {
+    resObj.joins = [];
+    for (const joinName in object.joins) {
+      const join = object.joins[joinName];
+      resObj.joins.push({
+        sql: join.sql,
+      });
+    }
+  }
+  return resObj;
+}
+
+function convertMeasure(measure: any): any {
+  switch (measure.type) {
+    case 'count':
+      return {
+        sql: measure.sql ? 'COUNT(' + measure.sql + ')' : 'COUNT(*)',
+        type: 'number',
+      };
+    case 'count_distinct':
+      return {
+        sql: 'COUNT(DISTINCT ' + measure.sql + ')',
+        type: 'number',
+      };
+    case 'count_distinct_approx':
+      return {
+        sql: 'COUNT(DISTINCT ' + measure.sql + ')',
+        type: 'number',
+      };
+    case 'sum':
+      return {
+        sql: 'SUM(' + measure.sql + ')',
+        type: 'number',
+      };
+    case 'avg':
+      return {
+        sql: 'AVG(' + measure.sql + ')',
+        type: 'number',
+      };
+    case 'min':
+      return {
+        sql: 'MIN(' + measure.sql + ')',
+        type: 'number',
+      };
+    case 'max':
+      return {
+        sql: 'MAX(' + measure.sql + ')',
+        type: 'number',
+      };
+    default:
+      return {
+        sql: measure.sql,
+        type: measure.type,
+      };
+  }
+}

--- a/meerkat-core/src/utils/cube-to-table-schema.ts
+++ b/meerkat-core/src/utils/cube-to-table-schema.ts
@@ -1,4 +1,4 @@
-import { TableSchema } from '@devrev/meerkat-core';
+import { TableSchema } from '../types/cube-types/table';
 
 export function convertCubeToTableSchema(file: string): TableSchema | null {
   const cube = (name: any, object: any) => ({ name, object });

--- a/meerkat-node/src/__tests__/cube-schema-to-sql.spec.ts
+++ b/meerkat-node/src/__tests__/cube-schema-to-sql.spec.ts
@@ -1,0 +1,76 @@
+import { convertCubeStringToTableSchema } from '@devrev/meerkat-core';
+import { cubeQueryToSQL } from '../cube-to-sql/cube-to-sql';
+import { duckdbExec } from '../duckdb-exec';
+
+export const CREATE_PRODUCTS_TABLE = `
+CREATE TABLE products (
+    id INTEGER,
+    name VARCHAR,
+    description VARCHAR,
+    created_at TIMESTAMP,
+    supplier_id INTEGER
+);
+`;
+export const CREATE_SUPPLIERS_TABLE = `
+CREATE TABLE suppliers (
+    id INTEGER,
+    address VARCHAR,
+    email VARCHAR,
+    company VARCHAR,
+    created_at TIMESTAMP
+);
+`;
+
+export const INPUT_PRODUCTS_DATA = `
+INSERT INTO products VALUES
+(1, 'Pencil', 'It is a pencil', '2022-01-01', 1),
+(2, 'Pen', 'It is a pen', '2022-01-02', 1),
+(3, 'Eraser', 'It is an eraser', '2022-02-01', 2); 
+`;
+
+export const INPUT_SUPPLIERS_DATA = `
+INSERT INTO suppliers VALUES
+(1, '123 Main St', 'john@gmail.com', 'john doe', '2022-01-01'),
+(2, '456 Main St', 'steve@gmail.com', 'steve smith', '2022-01-02'); 
+`;
+
+describe('Cube Schema to SQL', () => {
+  beforeAll(async () => {
+    await duckdbExec(CREATE_PRODUCTS_TABLE);
+    await duckdbExec(CREATE_SUPPLIERS_TABLE);
+    await duckdbExec(INPUT_PRODUCTS_DATA);
+    await duckdbExec(INPUT_SUPPLIERS_DATA);
+  });
+
+  it('Should be able to execute sql query from cube string', async () => {
+    const productsFile =
+      "cube('products', { sql_table: 'select * from products', joins: { suppliers: { sql: `products.supplier_id = ${suppliers}.id`, relationship: 'many_to_one' } }, dimensions: { id: { sql: 'id', type: 'number', primary_key: true }, name: { sql: 'name', type: 'string' }, description: { sql: 'description', type: 'string' }, created_at: { sql: 'products.created_at', type: 'time' } }, measures: { count: { type: 'count' } }, pre_aggregations: {} });";
+    const suppliersFile =
+      "cube('suppliers', { sql_table: 'select * from suppliers', joins: {}, dimensions: { id: { sql: 'id', type: 'number', primary_key: true }, address: { sql: 'address', type: 'string' }, email: { sql: 'email', type: 'string' }, company: { sql: 'company', type: 'string' }, created_at: { sql: 'suppliers.created_at', type: 'time' } }, measures: { count: { type: 'count' } }, pre_aggregations: {} });";
+    const productsSchema = convertCubeStringToTableSchema(productsFile);
+    const suppliersSchema = convertCubeStringToTableSchema(suppliersFile);
+    const query = {
+      measures: ['products.count'],
+      filters: [],
+      dimensions: ['suppliers.created_at', 'products.created_at'],
+      joinPaths: [
+        [
+          {
+            left: 'products',
+            on: 'supplier_id',
+            right: 'suppliers',
+          },
+        ],
+      ],
+    };
+    const sql = await cubeQueryToSQL(query, [productsSchema, suppliersSchema]);
+    console.info(`SQL for Simple Cube Query: `, sql);
+    const output = await duckdbExec(sql);
+    const parsedOutput = JSON.parse(JSON.stringify(output));
+    console.info('parsedOutput', parsedOutput);
+    expect(sql).toEqual(
+      'SELECT COUNT(*) AS products__count ,   suppliers__created_at,  products__created_at FROM (SELECT *, products.created_at AS products__created_at FROM (select * from products) AS products LEFT JOIN (SELECT *, suppliers.created_at AS suppliers__created_at FROM (select * from suppliers) AS suppliers) AS suppliers  ON products.supplier_id = suppliers.id) AS MEERKAT_GENERATED_TABLE GROUP BY suppliers__created_at, products__created_at'
+    );
+    expect(parsedOutput).toHaveLength(3);
+  });
+});

--- a/meerkat-node/src/index.ts
+++ b/meerkat-node/src/index.ts
@@ -1,3 +1,5 @@
 export * from './cube-to-sql/cube-to-sql';
 export * from './duckdb-singleton';
 export * from './node-sql-to-serialization';
+export { convertCubeStringToTableSchema };
+import { convertCubeStringToTableSchema } from '@devrev/meerkat-core';


### PR DESCRIPTION
Convert Cube JS string to Meerkat table schema

- Implemented parsing logic to extract table name, dimensions, measures, and joins from the cube definition string.
- Constructed a TableSchema object based on the extracted information.
