### PR TITLE
fix: allow empty order by as an input

### DIFF
--- a/meerkat-core/src/ast-builder/ast-builder.ts
+++ b/meerkat-core/src/ast-builder/ast-builder.ts
@@ -124,7 +124,7 @@ export const cubeToDuckdbAST = (
     node.group_sets = [groupSets];
   }
   node.modifiers = [];
-  if (query.order) {
+  if (query.order && Object.keys(query.order).length > 0) {
     node.modifiers.push(cubeOrderByToAST(query.order));
   }
   if (query.limit || query.offset) {

--- a/meerkat-node/src/__tests__/cube-to-sql.spec.ts
+++ b/meerkat-node/src/__tests__/cube-to-sql.spec.ts
@@ -105,6 +105,22 @@ describe('cube-to-sql', () => {
 
   it('Without filter query generator with empty or', async () => {
     const query = {
+      measures: ['*'],
+      filters: [
+        {
+          or: [],
+        },
+      ],
+      dimensions: [],
+    };
+    const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
+    console.info(`SQL for Simple Cube Query: `, sql);
+    expect(sql).toEqual(
+      'SELECT orders.* FROM (SELECT * FROM (select * from orders) AS orders) AS orders'
+    );
+  });
+  it('Should handle empty order', async () => {
+    const query = {
       order: {},
       measures: ['*'],
       filters: [

--- a/meerkat-node/src/__tests__/cube-to-sql.spec.ts
+++ b/meerkat-node/src/__tests__/cube-to-sql.spec.ts
@@ -105,6 +105,7 @@ describe('cube-to-sql', () => {
 
   it('Without filter query generator with empty or', async () => {
     const query = {
+      order: {},
       measures: ['*'],
       filters: [
         {


### PR DESCRIPTION
https://app.devrev.ai/devrev/works/ISS-186977

Allow empty object as input