### PR TITLE
feat: add multi read table lock manager

### DIFF
--- a/meerkat-browser-runner/src/app/app.tsx
+++ b/meerkat-browser-runner/src/app/app.tsx
@@ -6,7 +6,7 @@ import {
   FileManagerType,
   getMainAppName,
   getRunnerAppName,
-  RunnerMemoryDBFileManager,
+  RunnerIndexedDBFileManager,
   WindowCommunication,
 } from '@devrev/meerkat-dbm';
 
@@ -72,7 +72,7 @@ export function App() {
   }
 
   if (!fileManagerRef.current) {
-    fileManagerRef.current = new RunnerMemoryDBFileManager({
+    fileManagerRef.current = new RunnerIndexedDBFileManager({
       instanceManager: instanceManagerRef.current,
       fetchTableFileBuffers: async () => [],
       logger: log,
@@ -82,7 +82,6 @@ export function App() {
           payload: event,
         });
       },
-      communication: communicationRef.current,
     });
   }
 

--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "dependencies": {
     "tslib": "^2.3.0",
     "@duckdb/duckdb-wasm": "1.28.1-dev258.0",

--- a/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
+++ b/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
@@ -128,6 +128,14 @@ export class DBMParallel extends TableLockManager {
         throw new Error('No runner found');
       }
 
+      /**
+       * Lock the tables
+       */
+      await this.lockTables(
+        tables.map((table) => table.name),
+        'read'
+      );
+
       const response =
         await runner.communication.sendRequest<BrowserRunnerExecQueryMessageResponse>(
           {
@@ -142,6 +150,14 @@ export class DBMParallel extends TableLockManager {
 
       const end = performance.now();
       this.logger.info(`Time to execute by DBM Parallel`, end - start);
+
+      /**
+       * Unlock the tables
+       */
+      this.unlockTables(
+        tables.map((table) => table.name),
+        'read'
+      );
 
       /**
        * The implementation is based on postMessage API, so we don't have the ability to throw an error from the runner

--- a/meerkat-dbm/src/dbm/types.ts
+++ b/meerkat-dbm/src/dbm/types.ts
@@ -112,9 +112,8 @@ export interface QueryQueueItem {
 }
 
 export interface TableLock {
-  promiseQueue: {
-    resolve: () => void;
-    reject: () => void;
-  }[];
-  isLocked: boolean;
+  readersCount: number;
+  writer: boolean;
+  readersQueue: (() => void)[];
+  writersQueue: (() => void)[];
 }


### PR DESCRIPTION
Enhance table lock manager to support multi read for dbm parallel

work-item: https://app.devrev.ai/devrev/works/ISS-190615