### PR TITLE
fixes for alias handling

### DIFF
--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-browser",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-browser",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/meerkat-core/src/cube-measure-transformer/cube-measure-transformer.ts
+++ b/meerkat-core/src/cube-measure-transformer/cube-measure-transformer.ts
@@ -34,9 +34,13 @@ export const cubeMeasureToSQLSelectString = (
     if (i > 0) {
       base += ', ';
     }
+
+    // Note that tableSchemaName is not necessarily the same as tableSchema.name
+    // since tableSchema might be the merged tableSchema.
     let meerkatReplacedSqlString = meerkatPlaceholderReplacer(
       measureSchema.sql,
-      tableSchema.name
+      tableSchemaName,
+      tableSchema
     );
 
     /**

--- a/meerkat-core/src/get-final-base-sql/get-final-base-sql.spec.ts
+++ b/meerkat-core/src/get-final-base-sql/get-final-base-sql.spec.ts
@@ -44,7 +44,7 @@ describe('get final base sql', () => {
       getQueryOutput,
     });
     expect(result).toEqual(
-      'SELECT *, amount AS orders__amount, status AS orders__status FROM (select * from orders WHERE  ((orders.status IS NOT NULL))) AS orders'
+      'SELECT amount AS orders__amount, status AS orders__status, * FROM (select * from orders WHERE  ((orders.status IS NOT NULL))) AS orders'
     );
   });
   it('should not return measures in the projected base sql when filter param not passed', async () => {
@@ -62,7 +62,7 @@ describe('get final base sql', () => {
       getQueryOutput,
     });
     expect(result).toEqual(
-      'SELECT *, amount AS orders__amount, status AS orders__status FROM (select * from orders WHERE TRUE) AS orders'
+      'SELECT amount AS orders__amount, status AS orders__status, * FROM (select * from orders WHERE TRUE) AS orders'
     );
   });
 
@@ -110,7 +110,7 @@ describe('get final base sql', () => {
       getQueryOutput,
     });
     expect(result).toEqual(
-      'SELECT *, amount AS "order amount", status AS "order status" FROM (select * from orders WHERE  ((orders.status IS NOT NULL))) AS orders'
+      'SELECT amount AS "order amount", status AS "order status", * FROM (select * from orders WHERE  ((orders.status IS NOT NULL))) AS orders'
     );
   });
 });

--- a/meerkat-core/src/get-wrapped-base-query-with-projections/get-wrapped-base-query-with-projections.ts
+++ b/meerkat-core/src/get-wrapped-base-query-with-projections/get-wrapped-base-query-with-projections.ts
@@ -1,9 +1,7 @@
 import { getSelectReplacedSql } from '../cube-measure-transformer/cube-measure-transformer';
 import { Query, TableSchema } from '../types/cube-types';
 import { getAliasedColumnsFromFilters } from './get-aliased-columns-from-filters';
-import {
-  getProjectionClause
-} from './get-projection-clause';
+import { getProjectionClause } from './get-projection-clause';
 
 interface GetWrappedBaseQueryWithProjectionsParams {
   baseQuery: string;
@@ -32,19 +30,17 @@ export const getWrappedBaseQueryWithProjections = ({
 
   const aliasFromFilters = getAliasedColumnsFromFilters({
     aliasedColumnSet,
-    baseSql: 'SELECT *',
     // setting measures to empty array, since we don't want to project measures present in the filters in the base query
     tableSchema: tableSchema,
     query,
     meerkatFilters: query.filters,
   });
 
-  const formattedMemberProjection = memberProjections
-    ? `, ${memberProjections}`
-    : '';
-
-  const finalAliasedColumnsClause =
-    aliasFromFilters + formattedMemberProjection;
+  const parts = [aliasFromFilters, memberProjections].filter(
+    (part) => part !== ''
+  );
+  parts.push('*');
+  const finalAliasedColumnsClause = 'SELECT ' + parts.join(', ');
 
   const sqlWithFilterProjects = getSelectReplacedSql(
     newBaseSql,

--- a/meerkat-core/src/utils/meerkat-placeholder-replacer.spec.ts
+++ b/meerkat-core/src/utils/meerkat-placeholder-replacer.spec.ts
@@ -1,41 +1,70 @@
+import { TableSchema } from '../types/cube-types';
 import { meerkatPlaceholderReplacer } from './meerkat-placeholder-replacer';
 
-describe("meerkatPlaceholderReplacer", () => {
-    it("should not replace placeholders with tableName if placeholder pattern doesnt end in .", () => {
-        const sql = "SELECT * FROM {MEERKAT}fieldName";
-        const tableName = "customers";
-        expect(meerkatPlaceholderReplacer(sql, tableName)).toEqual("SELECT * FROM {MEERKAT}fieldName");
-    });
+describe('meerkatPlaceholderReplacer', () => {
+  let tableSchema: TableSchema;
+  beforeEach(() => {
+    tableSchema = {
+      name: 'test',
+      sql: 'test',
+      measures: [
+        { name: 'measure1', sql: 'COUNT(*)', type: 'number', alias: 'alias1' },
+      ],
+      dimensions: [],
+    };
+  });
 
-    it("should replace multiple placeholders in the SQL query", () => {
-        const sql = "SELECT {MEERKAT}.a, {MEERKAT}.b FROM orders";
-        const tableName = "orders";
-        expect(meerkatPlaceholderReplacer(sql, tableName)).toEqual('SELECT orders__a, orders__b FROM orders');
-    });
+  it('should not replace placeholders with tableName if placeholder pattern doesnt end in .', () => {
+    const sql = 'SELECT * FROM {MEERKAT}fieldName';
+    const tableName = 'customers';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual(
+      'SELECT * FROM {MEERKAT}fieldName'
+    );
+  });
 
-    it("should be case sensitive", () => {
-        const sql = "SELECT {meerkat}.a FROM orders";
-        const tableName = "orders";
-        expect(meerkatPlaceholderReplacer(sql, tableName)).toEqual('SELECT {meerkat}.a FROM orders');
-    });
+  it('should replace multiple placeholders in the SQL query', () => {
+    const sql = 'SELECT {MEERKAT}.a, {MEERKAT}.b FROM orders';
+    const tableName = 'orders';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual(
+      'SELECT orders__a, orders__b FROM orders'
+    );
+  });
 
-    it("should replace the correct match", () => {
-        const sql = "SELECT {MEERKAT.{MEERKAT}.}.a FROM customers";
-        const tableName = "customers";
-        expect(meerkatPlaceholderReplacer(sql, tableName)).toEqual("SELECT {MEERKAT.customers__}.a FROM customers");
-    });
+  it('should be case sensitive', () => {
+    const sql = 'SELECT {meerkat}.a FROM orders';
+    const tableName = 'orders';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual(
+      'SELECT {meerkat}.a FROM orders'
+    );
+  });
 
-    it("should handle empty SQL queries", () => {
-        const sql = "";
-        const tableName = "customers";
-        expect(meerkatPlaceholderReplacer(sql, tableName)).toEqual('');
-    });
+  it('should replace the correct match', () => {
+    const sql = 'SELECT {MEERKAT.{MEERKAT}.a}.a FROM customers';
+    const tableName = 'customers';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual(
+      'SELECT {MEERKAT.customers__a}.a FROM customers'
+    );
+  });
 
-    it("should handle SQL queries without placeholders", () => {
-        const sql = "SELECT * FROM customers.";
-        const tableName = "orders";
-        expect(meerkatPlaceholderReplacer(sql, tableName)).toEqual('SELECT * FROM customers.');
-    });
+  it('should handle empty SQL queries', () => {
+    const sql = '';
+    const tableName = 'customers';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual('');
+  });
 
-    
+  it('should handle SQL queries without placeholders', () => {
+    const sql = 'SELECT * FROM customers.';
+    const tableName = 'orders';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual(
+      'SELECT * FROM customers.'
+    );
+  });
+
+  it('should replace placeholders with alias if provided', () => {
+    const sql = 'SELECT {MEERKAT}.measure1 FROM orders';
+    const tableName = 'orders';
+    expect(meerkatPlaceholderReplacer(sql, tableName, tableSchema)).toEqual(
+      'SELECT "alias1" FROM orders'
+    );
+  });
 });

--- a/meerkat-core/src/utils/meerkat-placeholder-replacer.ts
+++ b/meerkat-core/src/utils/meerkat-placeholder-replacer.ts
@@ -1,9 +1,19 @@
-import { MEERKAT_OUTPUT_DELIMITER } from '../member-formatters/constants';
+import { getAliasFromSchema, getNamespacedKey } from '../member-formatters';
+import { TableSchema } from '../types/cube-types';
 
-export const meerkatPlaceholderReplacer = (sql: string, tableName: string) => {
-  const tableNameEncapsulationRegEx = /\{MEERKAT\}\./g;
-  return sql.replace(
-    tableNameEncapsulationRegEx,
-    tableName + MEERKAT_OUTPUT_DELIMITER
-  );
+export const meerkatPlaceholderReplacer = (
+  sql: string,
+  originalTableName: string,
+  tableSchema: TableSchema
+) => {
+  const tableNameEncapsulationRegEx = /\{MEERKAT\}\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+  return sql.replace(tableNameEncapsulationRegEx, (_, columnName) => {
+    return getAliasFromSchema({
+      name: getNamespacedKey(originalTableName, columnName),
+      tableSchema,
+      aliasContext: {
+        isAstIdentifier: false,
+      },
+    });
+  });
 };

--- a/meerkat-node/package.json
+++ b/meerkat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-node",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "dependencies": {
     "@swc/helpers": "~0.5.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-node/package.json
+++ b/meerkat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-node",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "dependencies": {
     "@swc/helpers": "~0.5.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-node/src/__tests__/aliases.spec.ts
+++ b/meerkat-node/src/__tests__/aliases.spec.ts
@@ -92,7 +92,7 @@ describe('cube-to-sql', () => {
     const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "Customer ID" FROM (SELECT *, customer_id AS "Customer ID" FROM (select * from orders) AS orders) AS orders GROUP BY "Customer ID"`
+      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "Customer ID" FROM (SELECT customer_id AS "Customer ID", * FROM (select * from orders) AS orders) AS orders GROUP BY "Customer ID"`
     );
     const output = await duckdbExec(sql);
     expect(output.length).toEqual(7);
@@ -118,7 +118,7 @@ describe('cube-to-sql', () => {
     const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "Customer ID" FROM (SELECT *, customer_id AS "Customer ID" FROM (select * from orders) AS orders) AS orders WHERE ("Customer ID" = '2') GROUP BY "Customer ID" HAVING ("Total Order Amount" = 100)`
+      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "Customer ID" FROM (SELECT customer_id AS "Customer ID", * FROM (select * from orders) AS orders) AS orders WHERE ("Customer ID" = '2') GROUP BY "Customer ID" HAVING ("Total Order Amount" = 100)`
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -147,12 +147,53 @@ describe('cube-to-sql', () => {
     const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "Customer ID" FROM (SELECT *, customer_id AS "Customer ID" FROM (select * from orders) AS orders) AS orders WHERE ("Customer ID" = '2') GROUP BY "Customer ID" ORDER BY "Total Order Amount" DESC`
+      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "Customer ID" FROM (SELECT customer_id AS "Customer ID", * FROM (select * from orders) AS orders) AS orders WHERE ("Customer ID" = '2') GROUP BY "Customer ID" ORDER BY "Total Order Amount" DESC`
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
       {
         'Customer ID': '2',
+        'Total Order Amount': 100,
+      },
+    ]);
+  });
+
+  it('Should handle alias that conflicts with another column', async () => {
+    const tableSchemaWithConflict = {
+      ...TABLE_SCHEMA,
+      dimensions: [
+        {
+          name: 'customer_id',
+          sql: 'customer_id',
+          type: 'string',
+          alias: 'order_id', // This conflicts with the orderr_id dimension
+        },
+      ],
+    };
+
+    const query: Query = {
+      measures: ['orders.total_order_amount'],
+      filters: [
+        {
+          member: 'orders.customer_id',
+          operator: 'equals',
+          values: ['2'],
+        },
+      ],
+      dimensions: ['orders.customer_id'],
+    };
+    const sql = await cubeQueryToSQL({
+      query,
+      tableSchemas: [tableSchemaWithConflict],
+    });
+    console.info(`SQL for Simple Cube Query: `, sql);
+    expect(sql).toBe(
+      `SELECT SUM(order_amount) AS "Total Order Amount" ,   "order_id" FROM (SELECT customer_id AS "order_id", * FROM (select * from orders) AS orders) AS orders WHERE (order_id = '2') GROUP BY order_id`
+    );
+    const output = await duckdbExec(sql);
+    expect(output).toEqual([
+      {
+        order_id: '2',
         'Total Order Amount': 100,
       },
     ]);

--- a/meerkat-node/src/__tests__/cube-array-type.spec.ts
+++ b/meerkat-node/src/__tests__/cube-array-type.spec.ts
@@ -90,7 +90,7 @@ describe('cube-to-sql', () => {
     };
     const sql = await cubeQueryToSQL({ query, tableSchemas: [SCHEMA] });
     expect(sql).toBe(
-      `SELECT person.* FROM (SELECT *, activities AS person__activities FROM (select * from person) AS person) AS person WHERE list_has_all(person__activities, main.list_value('Hiking'))`
+      `SELECT person.* FROM (SELECT activities AS person__activities, * FROM (select * from person) AS person) AS person WHERE list_has_all(person__activities, main.list_value('Hiking'))`
     );
     const output: any = await duckdbExec(sql);
     expect(output).toHaveLength(1);
@@ -120,7 +120,7 @@ describe('cube-to-sql', () => {
     };
     const sql = await cubeQueryToSQL({ query, tableSchemas: [SCHEMA] });
     expect(sql).toBe(
-      `SELECT person.* FROM (SELECT *, activities AS person__activities, id AS person__id FROM (select * from person) AS person) AS person WHERE (list_has_all(person__activities, main.list_value('Running')) AND (person__id = '2'))`
+      `SELECT person.* FROM (SELECT activities AS person__activities, id AS person__id, * FROM (select * from person) AS person) AS person WHERE (list_has_all(person__activities, main.list_value('Running')) AND (person__id = '2'))`
     );
     const output: any = await duckdbExec(sql);
     expect(output).toHaveLength(1);
@@ -142,7 +142,7 @@ describe('cube-to-sql', () => {
     const sql = await cubeQueryToSQL({ query, tableSchemas: [SCHEMA] });
     console.info('SQL: ', sql);
     expect(sql).toBe(
-      `SELECT person.* FROM (SELECT *, activities AS person__activities FROM (select * from person) AS person) AS person WHERE (NOT list_has_all(person__activities, main.list_value('Running')))`
+      `SELECT person.* FROM (SELECT activities AS person__activities, * FROM (select * from person) AS person) AS person WHERE (NOT list_has_all(person__activities, main.list_value('Running')))`
     );
     const output: any = await duckdbExec(sql);
     expect(output).toHaveLength(2);

--- a/meerkat-node/src/__tests__/cube-projection-filters.spec.ts
+++ b/meerkat-node/src/__tests__/cube-projection-filters.spec.ts
@@ -75,7 +75,7 @@ describe('cube-to-sql', () => {
 
   it('Should construct the SQL query and apply filter on projections', async () => {
     const sql = await cubeQueryToSQL({ query: QUERY, tableSchemas: [SCHEMA] });
-    const expectedSQL = `SELECT COUNT(DISTINCT id) AS person__count_star ,   person__other_dimension FROM (SELECT *, CASE WHEN primary_part_id LIKE '%enhancement%' THEN 'yes' ELSE 'no' END AS person__ticket_prioritized, 'dashboard_others' AS person__other_dimension FROM (SELECT * FROM person) AS person) AS person WHERE ((person__ticket_prioritized != 'no')) GROUP BY person__other_dimension`;
+    const expectedSQL = `SELECT COUNT(DISTINCT id) AS person__count_star ,   person__other_dimension FROM (SELECT CASE WHEN primary_part_id LIKE '%enhancement%' THEN 'yes' ELSE 'no' END AS person__ticket_prioritized, 'dashboard_others' AS person__other_dimension, * FROM (SELECT * FROM person) AS person) AS person WHERE ((person__ticket_prioritized != 'no')) GROUP BY person__other_dimension`;
     expect(sql).toBe(expectedSQL);
     console.info('SQL: ', sql);
     const output: any = await duckdbExec(sql);
@@ -115,7 +115,7 @@ describe('cube-to-sql', () => {
       },
       tableSchemas: [SCHEMA],
     });
-    const expectedSQL = `SELECT COUNT(DISTINCT id) AS person__count_star ,   person__other_dimension FROM (SELECT *, id AS person__id, CASE WHEN primary_part_id LIKE '%enhancement%' THEN 'yes' ELSE 'no' END AS person__ticket_prioritized, 'dashboard_others' AS person__other_dimension FROM (SELECT * FROM person) AS person) AS person WHERE (((person__id != '1') OR (person__ticket_prioritized != 'no'))) GROUP BY person__other_dimension`;
+    const expectedSQL = `SELECT COUNT(DISTINCT id) AS person__count_star ,   person__other_dimension FROM (SELECT id AS person__id, CASE WHEN primary_part_id LIKE '%enhancement%' THEN 'yes' ELSE 'no' END AS person__ticket_prioritized, 'dashboard_others' AS person__other_dimension, * FROM (SELECT * FROM person) AS person) AS person WHERE (((person__id != '1') OR (person__ticket_prioritized != 'no'))) GROUP BY person__other_dimension`;
     expect(sql).toBe(expectedSQL);
     console.info('SQL: ', sql);
     const output: any = await duckdbExec(sql);
@@ -160,7 +160,7 @@ describe('cube-to-sql', () => {
       },
       tableSchemas: [SCHEMA],
     });
-    const expectedSQL = `SELECT COUNT(DISTINCT id) AS person__count_star ,   person__other_dimension FROM (SELECT *, id AS person__id, CASE WHEN primary_part_id LIKE '%enhancement%' THEN 'yes' ELSE 'no' END AS person__ticket_prioritized, 'dashboard_others' AS person__other_dimension FROM (SELECT * FROM person) AS person) AS person WHERE ((person__id != '2') AND ((person__id != '1') OR (person__ticket_prioritized != 'no'))) GROUP BY person__other_dimension`;
+    const expectedSQL = `SELECT COUNT(DISTINCT id) AS person__count_star ,   person__other_dimension FROM (SELECT id AS person__id, CASE WHEN primary_part_id LIKE '%enhancement%' THEN 'yes' ELSE 'no' END AS person__ticket_prioritized, 'dashboard_others' AS person__other_dimension, * FROM (SELECT * FROM person) AS person) AS person WHERE ((person__id != '2') AND ((person__id != '1') OR (person__ticket_prioritized != 'no'))) GROUP BY person__other_dimension`;
     expect(sql).toBe(expectedSQL);
     console.info('SQL: ', sql);
     const output: any = await duckdbExec(sql);

--- a/meerkat-node/src/__tests__/cube-schema-to-sql.spec.ts
+++ b/meerkat-node/src/__tests__/cube-schema-to-sql.spec.ts
@@ -63,12 +63,15 @@ describe('Cube Schema to SQL', () => {
         ],
       ],
     };
-    const sql = await cubeQueryToSQL({ query, tableSchemas: [productsSchema, suppliersSchema] });
+    const sql = await cubeQueryToSQL({
+      query,
+      tableSchemas: [productsSchema, suppliersSchema],
+    });
     console.info(`SQL for Simple Cube Query: `, sql);
     const output = await duckdbExec(sql);
     console.info('parsedOutput', output);
     expect(sql).toEqual(
-      'SELECT COUNT(*) AS products__count ,   suppliers__created_at,  products__created_at FROM (SELECT *, products.created_at AS products__created_at FROM (select * from products) AS products LEFT JOIN (SELECT *, suppliers.created_at AS suppliers__created_at FROM (select * from suppliers) AS suppliers) AS suppliers  ON products.supplier_id = suppliers.id) AS MEERKAT_GENERATED_TABLE GROUP BY suppliers__created_at, products__created_at'
+      'SELECT COUNT(*) AS products__count ,   suppliers__created_at,  products__created_at FROM (SELECT products.created_at AS products__created_at, * FROM (select * from products) AS products LEFT JOIN (SELECT suppliers.created_at AS suppliers__created_at, * FROM (select * from suppliers) AS suppliers) AS suppliers  ON products.supplier_id = suppliers.id) AS MEERKAT_GENERATED_TABLE GROUP BY suppliers__created_at, products__created_at'
     );
     expect(output).toHaveLength(3);
   });

--- a/meerkat-node/src/__tests__/having-filters.spec.ts
+++ b/meerkat-node/src/__tests__/having-filters.spec.ts
@@ -101,7 +101,7 @@ describe('cube-to-sql', () => {
     const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id = '2') GROUP BY orders__customer_id HAVING (orders__total_order_amount = 100) ORDER BY orders__total_order_amount DESC LIMIT 2`
+      `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id = '2') GROUP BY orders__customer_id HAVING (orders__total_order_amount = 100) ORDER BY orders__total_order_amount DESC LIMIT 2`
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -131,7 +131,7 @@ describe('cube-to-sql', () => {
     const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT *, orders.order_amount AS orders__order_amount, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE (orders__order_amount = 100) GROUP BY orders__customer_id ORDER BY orders__total_order_amount DESC LIMIT 2`
+      `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT orders.order_amount AS orders__order_amount, customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE (orders__order_amount = 100) GROUP BY orders__customer_id ORDER BY orders__total_order_amount DESC LIMIT 2`
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([

--- a/meerkat-node/src/__tests__/joins.spec.ts
+++ b/meerkat-node/src/__tests__/joins.spec.ts
@@ -300,8 +300,13 @@ describe('Joins Tests', () => {
       dimensions: ['authors.author_name'],
     };
     await expect(
-      cubeQueryToSQL({ query: query, tableSchemas: [BOOK_SCHEMA, AUTHOR_SCHEMA] })
-    ).rejects.toThrow('Invalid path, multiple data sources are present without a join path.');
+      cubeQueryToSQL({
+        query: query,
+        tableSchemas: [BOOK_SCHEMA, AUTHOR_SCHEMA],
+      })
+    ).rejects.toThrow(
+      'Invalid path, multiple data sources are present without a join path.'
+    );
   });
 
   it('Loops in the join paths', async () => {
@@ -325,7 +330,7 @@ describe('Joins Tests', () => {
       dimensions: ['authors.author_name'],
     };
     await expect(
-      cubeQueryToSQL({query, tableSchemas: [BOOK_SCHEMA, AUTHOR_SCHEMA]})
+      cubeQueryToSQL({ query, tableSchemas: [BOOK_SCHEMA, AUTHOR_SCHEMA] })
     ).rejects.toThrow(`A loop was detected in the joins.`);
   });
 
@@ -354,12 +359,15 @@ describe('Joins Tests', () => {
       dimensions: ['customers.customer_id', 'orders.customer_id'],
     };
     await expect(
-      cubeQueryToSQL({query, tableSchemas: [
-        BOOK_SCHEMA,
-        CUSTOMER_SCHEMA,
-        ORDER_SCHEMA,
-        AUTHOR_SCHEMA,
-      ]})
+      cubeQueryToSQL({
+        query,
+        tableSchemas: [
+          BOOK_SCHEMA,
+          CUSTOMER_SCHEMA,
+          ORDER_SCHEMA,
+          AUTHOR_SCHEMA,
+        ],
+      })
     ).rejects.toThrow(
       'Invalid path, starting node is not the same for all paths.'
     );
@@ -379,13 +387,16 @@ describe('Joins Tests', () => {
         ],
       ],
     };
-    const sql = await cubeQueryToSQL({ query, tableSchemas: [AUTHOR_SCHEMA, ORDER_SCHEMA]});
+    const sql = await cubeQueryToSQL({
+      query,
+      tableSchemas: [AUTHOR_SCHEMA, ORDER_SCHEMA],
+    });
     console.info(`SQL for Simple Cube Query: `, sql);
     const output = await duckdbExec(sql);
     const parsedOutput = JSON.parse(JSON.stringify(output));
     console.info('parsedOutput', parsedOutput);
     expect(sql).toEqual(
-      'SELECT  orders__order_id FROM (SELECT *, orders.order_id AS orders__order_id FROM (select * from orders) AS orders) AS MEERKAT_GENERATED_TABLE'
+      'SELECT  orders__order_id FROM (SELECT orders.order_id AS orders__order_id, * FROM (select * from orders) AS orders) AS MEERKAT_GENERATED_TABLE'
     );
     expect(parsedOutput).toHaveLength(11);
   });
@@ -439,11 +450,7 @@ describe('Joins Tests', () => {
     };
     const sql = await cubeQueryToSQL({
       query,
-      tableSchemas: [
-        DEMO_SCHEMA,
-        CUSTOMER_SCHEMA,
-        PRODUCT_SCHEMA,
-      ]
+      tableSchemas: [DEMO_SCHEMA, CUSTOMER_SCHEMA, PRODUCT_SCHEMA],
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     const output = await duckdbExec(sql);
@@ -499,11 +506,10 @@ describe('Joins Tests', () => {
         'customers.customer_id',
       ],
     };
-    const sql = await cubeQueryToSQL({query, tableSchemas: [
-      ORDER_SCHEMA,
-      DEMO_SCHEMA,
-      PRODUCT_SCHEMA,
-    ]});
+    const sql = await cubeQueryToSQL({
+      query,
+      tableSchemas: [ORDER_SCHEMA, DEMO_SCHEMA, PRODUCT_SCHEMA],
+    });
     console.info(`SQL for Simple Cube Query: `, sql);
     const output = await duckdbExec(sql);
     const parsedOutput = JSON.parse(JSON.stringify(output));
@@ -550,11 +556,14 @@ describe('Joins Tests', () => {
       ],
       order: {
         'orders.total_order_amount': 'desc',
-        'customers.customer_id': 'asc'
+        'customers.customer_id': 'asc',
       },
     };
 
-    const sql = await cubeQueryToSQL({ query: query1, tableSchemas: [ORDER_SCHEMA, CUSTOMER_SCHEMA] });
+    const sql = await cubeQueryToSQL({
+      query: query1,
+      tableSchemas: [ORDER_SCHEMA, CUSTOMER_SCHEMA],
+    });
     console.info(`SQL for Simple Cube Query: `, sql);
     const output = await duckdbExec(sql);
     const parsedOutput = JSON.parse(JSON.stringify(output));
@@ -601,7 +610,10 @@ describe('Joins Tests', () => {
       ],
     };
 
-    const sql2 = await cubeQueryToSQL({ query: query2, tableSchemas: [ORDER_SCHEMA, CUSTOMER_SCHEMA] });
+    const sql2 = await cubeQueryToSQL({
+      query: query2,
+      tableSchemas: [ORDER_SCHEMA, CUSTOMER_SCHEMA],
+    });
     const output2 = await duckdbExec(sql2);
     const parsedOutput2 = JSON.parse(JSON.stringify(output2));
     expect(parsedOutput2).toHaveLength(1);
@@ -643,7 +655,10 @@ describe('Joins Tests', () => {
       },
       limit: 2,
     };
-    const sql = await cubeQueryToSQL({ query, tableSchemas: [ORDER_SCHEMA, CUSTOMER_SCHEMA] });
+    const sql = await cubeQueryToSQL({
+      query,
+      tableSchemas: [ORDER_SCHEMA, CUSTOMER_SCHEMA],
+    });
     console.info(`SQL for Simple Cube Query: `, sql);
     const output = await duckdbExec(sql);
     const parsedOutput = JSON.parse(JSON.stringify(output));

--- a/meerkat-node/src/__tests__/meerkat-placeholder.spec.ts
+++ b/meerkat-node/src/__tests__/meerkat-placeholder.spec.ts
@@ -38,7 +38,7 @@ describe('meerkat placeholder', () => {
         orders__total_sum_amount: 'desc',
         'orders.sum_amount': 'desc',
         'orders.stage': 'desc',
-        'orders.owned_by_id': 'desc'
+        'orders.owned_by_id': 'desc',
       },
       timeDimensions: [],
       type: 'sql',
@@ -82,10 +82,10 @@ describe('meerkat placeholder', () => {
     const baseOutput = await duckdbExec(baseQuery);
     console.log({ baseOutput });
 
-    const sql = await cubeQueryToSQL({ query, tableSchemas: [tableSchema]});
+    const sql = await cubeQueryToSQL({ query, tableSchemas: [tableSchema] });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toEqual(
-     `SELECT SUM(amount) AS orders__sum_amount ,  SUM(SUM(amount)) OVER (PARTITION BY orders__owned_by_id) AS orders__total_sum_amount ,   orders__owned_by_id,  orders__stage FROM (SELECT *, owned_by_id AS orders__owned_by_id, stage AS orders__stage FROM (SELECT * FROM orders) AS orders) AS orders GROUP BY orders__owned_by_id, orders__stage ORDER BY orders__total_sum_amount DESC, orders__sum_amount DESC, orders__stage DESC, orders__owned_by_id DESC`
+      `SELECT SUM(amount) AS orders__sum_amount ,  SUM(SUM(amount)) OVER (PARTITION BY orders__owned_by_id) AS orders__total_sum_amount ,   orders__owned_by_id,  orders__stage FROM (SELECT owned_by_id AS orders__owned_by_id, stage AS orders__stage, * FROM (SELECT * FROM orders) AS orders) AS orders GROUP BY orders__owned_by_id, orders__stage ORDER BY orders__total_sum_amount DESC, orders__sum_amount DESC, orders__stage DESC, orders__owned_by_id DESC`
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -114,8 +114,8 @@ describe('meerkat placeholder', () => {
         orders__stage: 'stage_b',
       },
       {
-        "orders__stage": "stage_c",
-        "orders__sum_amount": 80,
+        orders__stage: 'stage_c',
+        orders__sum_amount: 80,
         orders__total_sum_amount: 145,
         orders__owned_by_id: 'user_1',
       },
@@ -126,7 +126,7 @@ describe('meerkat placeholder', () => {
         orders__stage: 'stage_a',
       },
       {
-        orders__stage: "stage_b",
+        orders__stage: 'stage_b',
         orders__sum_amount: 5,
         orders__total_sum_amount: 145,
         orders__owned_by_id: 'user_1',

--- a/meerkat-node/src/__tests__/only-dimensions-no-group-by.spec.ts
+++ b/meerkat-node/src/__tests__/only-dimensions-no-group-by.spec.ts
@@ -2,7 +2,6 @@ import { Query } from '@devrev/meerkat-core';
 import { cubeQueryToSQL } from '../cube-to-sql/cube-to-sql';
 import { duckdbExec } from '../duckdb-exec';
 
-
 const CREATE_TEST_TABLE = `CREATE TABLE orders (
     order_id INTEGER,
     customer_id VARCHAR,
@@ -22,118 +21,119 @@ const INPUT_DATA_QUERY = `INSERT INTO orders VALUES
 `;
 
 export const TABLE_SCHEMA = {
-    name: 'orders',
-    sql: 'select * from orders',
-    measures: [
-      {
-        name: 'order_amount',
-        sql: 'order_amount',
-        type: 'number',
-      },
-      {
-        name: 'total_order_amount',
-        sql: 'SUM(order_amount)',
-        type: 'number',
-      },
-    ],
-    dimensions: [
-      {
-        name: 'order_date',
-        sql: 'order_date',
-        type: 'time',
-      },
-      {
-        name: 'order_id',
-        sql: 'order_id',
-        type: 'number',
-      },
-      {
-        name: 'customer_id',
-        sql: 'customer_id',
-        type: 'string',
-      },
-      {
-        name: 'product_id',
-        sql: 'product_id',
-        type: 'string',
-      },
-      {
-        name: 'order_month',
-        sql: `DATE_TRUNC('month', order_date)`,
-        type: 'string',
-      },
-    ],
+  name: 'orders',
+  sql: 'select * from orders',
+  measures: [
+    {
+      name: 'order_amount',
+      sql: 'order_amount',
+      type: 'number',
+    },
+    {
+      name: 'total_order_amount',
+      sql: 'SUM(order_amount)',
+      type: 'number',
+    },
+  ],
+  dimensions: [
+    {
+      name: 'order_date',
+      sql: 'order_date',
+      type: 'time',
+    },
+    {
+      name: 'order_id',
+      sql: 'order_id',
+      type: 'number',
+    },
+    {
+      name: 'customer_id',
+      sql: 'customer_id',
+      type: 'string',
+    },
+    {
+      name: 'product_id',
+      sql: 'product_id',
+      type: 'string',
+    },
+    {
+      name: 'order_month',
+      sql: `DATE_TRUNC('month', order_date)`,
+      type: 'string',
+    },
+  ],
 };
 describe('cube-to-sql', () => {
-    beforeAll(async () => {
+  beforeAll(async () => {
     //Create test table
     await duckdbExec(CREATE_TEST_TABLE);
     //Insert test data
     await duckdbExec(INPUT_DATA_QUERY);
     //Get SQL from cube query
-    });
-    it('Should not append group by when no measures selected', async () => {
-        const query: Query = {
-        measures: [],
-        dimensions: ['orders.customer_id'],
-        };
-        const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
-        console.info(`SQL for Simple Cube Query: `, sql);
-        expect(sql).toBe(
-            "SELECT  orders__customer_id FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders"
-        );
-        const output = await duckdbExec(sql);
-        expect(output).toEqual([
-               {
-                "orders__customer_id": "1",
-              },
-               {
-                "orders__customer_id": "1",
-              },
-               {
-                "orders__customer_id": "2",
-              },
-               {
-                "orders__customer_id": "2",
-              },
-               {
-                "orders__customer_id": "3",
-              },
-               {
-                "orders__customer_id": "4",
-              },
-               {
-                "orders__customer_id": "4",
-              },
-            ]
-        );
-    });
-    it('Should append group by when some measures are selected', async () => {
-        const query: Query = {
-          measures: ['orders.total_order_amount'],
-        dimensions: ['orders.customer_id'],
-        };
-        const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
-        console.info(`SQL for Simple Cube Query: `, sql);
-        expect(sql).toBe("SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders GROUP BY orders__customer_id");
-        const output = await duckdbExec(sql);
-        expect(output).toEqual([
-            {
-                "orders__customer_id": "1",
-                "orders__total_order_amount": 130,
-            },
-            {
-                "orders__customer_id": "2",
-                "orders__total_order_amount": 100,
-            },
-            {
-                "orders__customer_id": "3",
-                "orders__total_order_amount": 100,
-            },
-            {
-                "orders__customer_id": "4",
-                "orders__total_order_amount": 135,
-            },
-        ]);
-    });
+  });
+  it('Should not append group by when no measures selected', async () => {
+    const query: Query = {
+      measures: [],
+      dimensions: ['orders.customer_id'],
+    };
+    const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
+    console.info(`SQL for Simple Cube Query: `, sql);
+    expect(sql).toBe(
+      'SELECT  orders__customer_id FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders'
+    );
+    const output = await duckdbExec(sql);
+    expect(output).toEqual([
+      {
+        orders__customer_id: '1',
+      },
+      {
+        orders__customer_id: '1',
+      },
+      {
+        orders__customer_id: '2',
+      },
+      {
+        orders__customer_id: '2',
+      },
+      {
+        orders__customer_id: '3',
+      },
+      {
+        orders__customer_id: '4',
+      },
+      {
+        orders__customer_id: '4',
+      },
+    ]);
+  });
+  it('Should append group by when some measures are selected', async () => {
+    const query: Query = {
+      measures: ['orders.total_order_amount'],
+      dimensions: ['orders.customer_id'],
+    };
+    const sql = await cubeQueryToSQL({ query, tableSchemas: [TABLE_SCHEMA] });
+    console.info(`SQL for Simple Cube Query: `, sql);
+    expect(sql).toBe(
+      'SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders GROUP BY orders__customer_id'
+    );
+    const output = await duckdbExec(sql);
+    expect(output).toEqual([
+      {
+        orders__customer_id: '1',
+        orders__total_order_amount: 130,
+      },
+      {
+        orders__customer_id: '2',
+        orders__total_order_amount: 100,
+      },
+      {
+        orders__customer_id: '3',
+        orders__total_order_amount: 100,
+      },
+      {
+        orders__customer_id: '4',
+        orders__total_order_amount: 135,
+      },
+    ]);
+  });
 });

--- a/meerkat-node/src/__tests__/resolution.spec.ts
+++ b/meerkat-node/src/__tests__/resolution.spec.ts
@@ -156,11 +156,12 @@ describe('Resolution Tests', () => {
         base_table__work_id, 
         base_table__part_id_2 
       FROM 
-        (SELECT *,
+        (SELECT
           base_table.part_id_1 AS base_table__part_id_1, 
           base_table.random_column AS base_table__random_column, 
           base_table.work_id AS base_table__work_id, 
-          base_table.part_id_2 AS base_table__part_id_2 
+          base_table.part_id_2 AS base_table__part_id_2,
+          *
         FROM 
           (select * from base_table) 
         AS base_table) 
@@ -248,12 +249,12 @@ describe('Resolution Tests', () => {
         "base_table__work_id - title",  
         "base_table__part_id_2 - display_id" 
       FROM 
-        (SELECT *, __base_query.base_table__random_column AS "base_table__random_column" FROM (SELECT  base_table__part_id_1,  base_table__random_column,  base_table__work_id,  base_table__part_id_2 FROM (SELECT *, base_table.part_id_1 AS base_table__part_id_1, base_table.random_column AS base_table__random_column, base_table.work_id AS base_table__work_id, base_table.part_id_2 AS base_table__part_id_2 FROM (select * from base_table) AS base_table) AS base_table) AS __base_query 
-          LEFT JOIN (SELECT *, base_table__part_id_1.display_id AS "base_table__part_id_1 - display_id" FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_1) AS base_table__part_id_1  
+        (SELECT __base_query.base_table__random_column AS "base_table__random_column", * FROM (SELECT  base_table__part_id_1,  base_table__random_column,  base_table__work_id,  base_table__part_id_2 FROM (SELECT base_table.part_id_1 AS base_table__part_id_1, base_table.random_column AS base_table__random_column, base_table.work_id AS base_table__work_id, base_table.part_id_2 AS base_table__part_id_2, * FROM (select * from base_table) AS base_table) AS base_table) AS __base_query 
+          LEFT JOIN (SELECT base_table__part_id_1.display_id AS "base_table__part_id_1 - display_id", * FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_1) AS base_table__part_id_1  
           ON __base_query.base_table__part_id_1 = base_table__part_id_1.id 
-          LEFT JOIN (SELECT *, base_table__work_id.display_id AS "base_table__work_id - display_id", base_table__work_id.title AS "base_table__work_id - title" FROM (select id, display_id, title from system.dim_issue) AS base_table__work_id) AS base_table__work_id  
+          LEFT JOIN (SELECT base_table__work_id.display_id AS "base_table__work_id - display_id", base_table__work_id.title AS "base_table__work_id - title", * FROM (select id, display_id, title from system.dim_issue) AS base_table__work_id) AS base_table__work_id  
           ON __base_query.base_table__work_id = base_table__work_id.id 
-          LEFT JOIN (SELECT *, base_table__part_id_2.display_id AS "base_table__part_id_2 - display_id" FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_2) AS base_table__part_id_2  
+          LEFT JOIN (SELECT base_table__part_id_2.display_id AS "base_table__part_id_2 - display_id", * FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_2) AS base_table__part_id_2  
           ON __base_query.base_table__part_id_2 = base_table__part_id_2.id) 
       AS MEERKAT_GENERATED_TABLE
     `;
@@ -288,8 +289,8 @@ describe('Resolution Tests', () => {
         "base_table__count", 
         "base_table__part_id_1 - display_id" 
       FROM 
-        (SELECT *, __base_query.base_table__count AS "base_table__count" FROM (SELECT count(*) AS base_table__count , base_table__part_id_1 FROM (SELECT *, base_table.part_id_1 AS base_table__part_id_1 FROM (select * from base_table) AS base_table) AS base_table GROUP BY base_table__part_id_1) AS __base_query 
-          LEFT JOIN (SELECT *, base_table__part_id_1.display_id AS "base_table__part_id_1 - display_id" FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_1) AS base_table__part_id_1 
+        (SELECT __base_query.base_table__count AS "base_table__count", * FROM (SELECT count(*) AS base_table__count , base_table__part_id_1 FROM (SELECT base_table.part_id_1 AS base_table__part_id_1, * FROM (select * from base_table) AS base_table) AS base_table GROUP BY base_table__part_id_1) AS __base_query 
+          LEFT JOIN (SELECT base_table__part_id_1.display_id AS "base_table__part_id_1 - display_id", * FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_1) AS base_table__part_id_1 
           ON __base_query.base_table__part_id_1 = base_table__part_id_1.id) 
       AS MEERKAT_GENERATED_TABLE
     `;
@@ -336,10 +337,10 @@ describe('Resolution Tests', () => {
         "Random Column",  
         "Part ID 2 - Display ID" 
       FROM 
-        (SELECT *, __base_query."Random Column" AS "Random Column" FROM (SELECT  "Part ID 1",  "Random Column",  "Part ID 2" FROM (SELECT *, base_table.part_id_1 AS "Part ID 1", base_table.random_column AS "Random Column", base_table.part_id_2 AS "Part ID 2" FROM (select * from base_table) AS base_table) AS base_table) AS __base_query 
-          LEFT JOIN (SELECT *, base_table__part_id_1.display_id AS "Part ID 1 - Display ID" FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_1) AS base_table__part_id_1  
+        (SELECT __base_query."Random Column" AS "Random Column", * FROM (SELECT  "Part ID 1",  "Random Column",  "Part ID 2" FROM (SELECT base_table.part_id_1 AS "Part ID 1", base_table.random_column AS "Random Column", base_table.part_id_2 AS "Part ID 2", * FROM (select * from base_table) AS base_table) AS base_table) AS __base_query 
+          LEFT JOIN (SELECT base_table__part_id_1.display_id AS "Part ID 1 - Display ID", * FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_1) AS base_table__part_id_1  
           ON __base_query."Part ID 1" = base_table__part_id_1.id 
-          LEFT JOIN (SELECT *, base_table__part_id_2.display_id AS "Part ID 2 - Display ID" FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_2) AS base_table__part_id_2  
+          LEFT JOIN (SELECT base_table__part_id_2.display_id AS "Part ID 2 - Display ID", * FROM (select id, display_id from system.dim_feature UNION ALL select id, display_id from system.dim_product) AS base_table__part_id_2) AS base_table__part_id_2  
           ON __base_query."Part ID 2" = base_table__part_id_2.id) 
       AS MEERKAT_GENERATED_TABLE
     `;

--- a/meerkat-node/src/__tests__/test-data.ts
+++ b/meerkat-node/src/__tests__/test-data.ts
@@ -78,7 +78,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'GroupBySQLInnerQuery',
-      expectedSQL: `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__order_month FROM (SELECT *, DATE_TRUNC('month', order_date) AS orders__order_month FROM (select * from orders) AS orders) AS orders GROUP BY orders__order_month LIMIT 1`,
+      expectedSQL: `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__order_month FROM (SELECT DATE_TRUNC('month', order_date) AS orders__order_month, * FROM (select * from orders) AS orders) AS orders GROUP BY orders__order_month LIMIT 1`,
       cubeInput: {
         measures: ['orders.total_order_amount'],
         filters: [],
@@ -96,7 +96,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'GroupBy',
-      expectedSQL: `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders GROUP BY orders__customer_id ORDER BY orders__total_order_amount ASC, orders__customer_id ASC`,
+      expectedSQL: `SELECT SUM(order_amount) AS orders__total_order_amount ,   orders__customer_id FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders GROUP BY orders__customer_id ORDER BY orders__total_order_amount ASC, orders__customer_id ASC`,
       cubeInput: {
         measures: ['orders.total_order_amount'],
         filters: [],
@@ -145,7 +145,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'Equals',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id = '1')`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id = '1')`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -180,7 +180,7 @@ export const TEST_DATA = [
     },
     {
       testName: 'Equals for multiple values',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id = '1') AND (orders__customer_id = '2'))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id = '1') AND (orders__customer_id = '2'))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -198,7 +198,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'NotEquals',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id != '1')`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id != '1')`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -298,7 +298,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'Contains',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id ~~* '%aa%')`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE (orders__customer_id ~~* '%aa%')`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -326,7 +326,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'NotContains',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id !~~ '%1%') AND (orders__customer_id !~~ '%2%') AND (orders__customer_id !~~ '%3%') AND (orders__customer_id !~~ '%4%') AND (orders__customer_id !~~ '%5%') AND (orders__customer_id !~~ '%aa%'))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id !~~ '%1%') AND (orders__customer_id !~~ '%2%') AND (orders__customer_id !~~ '%3%') AND (orders__customer_id !~~ '%4%') AND (orders__customer_id !~~ '%5%') AND (orders__customer_id !~~ '%aa%'))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -383,7 +383,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'GreaterThan',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, orders.order_amount AS orders__order_amount FROM (select * from orders) AS orders) AS orders WHERE (orders__order_amount > 50)`,
+      expectedSQL: `SELECT orders.* FROM (SELECT orders.order_amount AS orders__order_amount, * FROM (select * from orders) AS orders) AS orders WHERE (orders__order_amount > 50)`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -475,7 +475,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'LessThan',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, orders.order_amount AS orders__order_amount FROM (select * from orders) AS orders) AS orders WHERE (orders__order_amount < 50)`,
+      expectedSQL: `SELECT orders.* FROM (SELECT orders.order_amount AS orders__order_amount, * FROM (select * from orders) AS orders) AS orders WHERE (orders__order_amount < 50)`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -521,7 +521,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'InDateRange',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, order_date AS orders__order_date FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_date >= '2022-02-01') AND (orders__order_date <= '2022-03-31'))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT order_date AS orders__order_date, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_date >= '2022-02-01') AND (orders__order_date <= '2022-03-31'))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -567,7 +567,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'NotInDateRange',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, order_date AS orders__order_date FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_date < '2022-02-01') OR (orders__order_date > '2022-03-31'))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT order_date AS orders__order_date, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_date < '2022-02-01') OR (orders__order_date > '2022-03-31'))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -735,7 +735,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'And',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, orders.order_amount AS orders__order_amount, order_date AS orders__order_date FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_amount > 50) AND ((orders__order_date >= '2022-02-01') AND (orders__order_date <= '2022-06-01')))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT orders.order_amount AS orders__order_amount, order_date AS orders__order_date, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_amount > 50) AND ((orders__order_date >= '2022-02-01') AND (orders__order_date <= '2022-06-01')))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -823,7 +823,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'Set',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, orders.order_amount AS orders__order_amount, product_id AS orders__product_id FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_amount IS NOT NULL) AND (orders__product_id = '3'))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT orders.order_amount AS orders__order_amount, product_id AS orders__product_id, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__order_amount IS NOT NULL) AND (orders__product_id = '3'))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -905,7 +905,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'Not Set',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id, product_id AS orders__product_id FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id IS NULL) AND (orders__product_id = '3'))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, product_id AS orders__product_id, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id IS NULL) AND (orders__product_id = '3'))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -943,7 +943,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'In',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id, vendors AS orders__vendors FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id IN ('1', '2')) AND (orders__vendors && (ARRAY['myntra', 'amazon'])))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, vendors AS orders__vendors, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id IN ('1', '2')) AND (orders__vendors && (ARRAY['myntra', 'amazon'])))`,
       cubeInput: {
         measures: ['*'],
         filters: [
@@ -993,7 +993,7 @@ export const TEST_DATA = [
   [
     {
       testName: 'Not In',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, customer_id AS orders__customer_id, vendors AS orders__vendors FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id NOT IN ('1', '2')) AND (NOT (orders__vendors && (ARRAY['myntra', 'flipkart']))))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT customer_id AS orders__customer_id, vendors AS orders__vendors, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__customer_id NOT IN ('1', '2')) AND (NOT (orders__vendors && (ARRAY['myntra', 'flipkart']))))`,
       cubeInput: {
         measures: ['*'],
         filters: [

--- a/meerkat-node/src/__tests__/test-data.ts
+++ b/meerkat-node/src/__tests__/test-data.ts
@@ -1034,7 +1034,7 @@ export const TEST_DATA = [
     },
     {
       testName: 'In with single quotes',
-      expectedSQL: `SELECT orders.* FROM (SELECT *, vendors AS orders__vendors FROM (select * from orders) AS orders) AS orders WHERE ((orders__vendors && (ARRAY['swiggy''s'])))`,
+      expectedSQL: `SELECT orders.* FROM (SELECT vendors AS orders__vendors, * FROM (select * from orders) AS orders) AS orders WHERE ((orders__vendors && (ARRAY['swiggy''s'])))`,
       cubeInput: {
         measures: ['*'],
         filters: [

--- a/meerkat-node/src/__tests__/unnest-group-by.spec.ts
+++ b/meerkat-node/src/__tests__/unnest-group-by.spec.ts
@@ -96,7 +96,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      'SELECT COUNT(*) AS tickets__count ,   tickets__owners FROM (SELECT *, array[unnest(owners)] AS tickets__owners FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__owners ORDER BY tickets__count DESC, tickets__owners DESC'
+      'SELECT COUNT(*) AS tickets__count ,   tickets__owners FROM (SELECT array[unnest(owners)] AS tickets__owners, * FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__owners ORDER BY tickets__count DESC, tickets__owners DESC'
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -145,7 +145,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      'SELECT COUNT(*) AS tickets__count ,   tickets__owners FROM (SELECT *, owners AS tickets__owners FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__owners ORDER BY tickets__count DESC, tickets__owners DESC'
+      'SELECT COUNT(*) AS tickets__count ,   tickets__owners FROM (SELECT owners AS tickets__owners, * FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__owners ORDER BY tickets__count DESC, tickets__owners DESC'
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -198,7 +198,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      'SELECT COUNT(*) AS tickets__count ,   tickets__created_by FROM (SELECT *, created_by AS tickets__created_by FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__created_by ORDER BY tickets__count DESC, tickets__created_by DESC'
+      'SELECT COUNT(*) AS tickets__count ,   tickets__created_by FROM (SELECT created_by AS tickets__created_by, * FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__created_by ORDER BY tickets__count DESC, tickets__created_by DESC'
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -239,7 +239,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      'SELECT COUNT(*) AS tickets__count ,   tickets__created_by FROM (SELECT *, created_by AS tickets__created_by FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__created_by ORDER BY tickets__count DESC, tickets__created_by DESC'
+      'SELECT COUNT(*) AS tickets__count ,   tickets__created_by FROM (SELECT created_by AS tickets__created_by, * FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__created_by ORDER BY tickets__count DESC, tickets__created_by DESC'
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -288,7 +288,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      'SELECT COUNT(*) AS tickets__count ,   tickets__created_by,  tickets__owners,  tickets__tags FROM (SELECT *, created_by AS tickets__created_by, array[unnest(owners)] AS tickets__owners, array[unnest(tags)] AS tickets__tags FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__created_by, tickets__owners, tickets__tags ORDER BY tickets__count DESC, tickets__created_by DESC, tickets__tags DESC, tickets__owners DESC'
+      'SELECT COUNT(*) AS tickets__count ,   tickets__created_by,  tickets__owners,  tickets__tags FROM (SELECT created_by AS tickets__created_by, array[unnest(owners)] AS tickets__owners, array[unnest(tags)] AS tickets__tags, * FROM (select * from tickets) AS tickets) AS tickets GROUP BY tickets__created_by, tickets__owners, tickets__tags ORDER BY tickets__count DESC, tickets__created_by DESC, tickets__tags DESC, tickets__owners DESC'
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -419,7 +419,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      "SELECT COUNT(*) AS tickets__count ,   tickets__tags FROM (SELECT *, owners AS tickets__owners, array[unnest(tags)] AS tickets__tags FROM (select * from tickets) AS tickets) AS tickets WHERE (list_has_all(tickets__owners, main.list_value('a'))) GROUP BY tickets__tags ORDER BY tickets__count DESC, tickets__tags DESC"
+      "SELECT COUNT(*) AS tickets__count ,   tickets__tags FROM (SELECT owners AS tickets__owners, array[unnest(tags)] AS tickets__tags, * FROM (select * from tickets) AS tickets) AS tickets WHERE (list_has_all(tickets__owners, main.list_value('a'))) GROUP BY tickets__tags ORDER BY tickets__count DESC, tickets__tags DESC"
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([
@@ -460,7 +460,7 @@ describe('cube-to-sql', () => {
     });
     console.info(`SQL for Simple Cube Query: `, sql);
     expect(sql).toBe(
-      'SELECT  tickets__owners FROM (SELECT *, owners AS tickets__owners FROM (select * from tickets) AS tickets) AS tickets ORDER BY tickets__owners DESC'
+      'SELECT  tickets__owners FROM (SELECT owners AS tickets__owners, * FROM (select * from tickets) AS tickets) AS tickets ORDER BY tickets__owners DESC'
     );
     const output = await duckdbExec(sql);
     expect(output).toEqual([


### PR DESCRIPTION
Fixes two bugs with aliasing

1. Handling `{MEERKAT}` syntax
2. Handling case where alias conflicts with a name in the dataset. By reordering the columns in the select clause, the alias now takes priority over these hidden columns.

https://app.devrev.ai/devrev/works/ISS-191518