### PR TITLE
chore: switch IDE test runner to vitest explorer

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "nrwl.angular-console",
     "esbenp.prettier-vscode",
-    "firsttris.vscode-jest-runner",
+    "vitest.explorer",
     "dbaeumer.vscode-eslint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,6 @@
     "javascriptreact",
     "typescript",
     "typescriptreact"
-  ]
+  ],
+  "vitest.workspaceConfig": "./vitest.workspace.ts"
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,5 @@
+export default [
+  'meerkat-node',
+  'meerkat-browser-runner',
+  'benchmarking',
+];


### PR DESCRIPTION
## Summary
- Replace `firsttris.vscode-jest-runner` with `vitest.explorer` in recommended extensions
- Add `vitest.workspace.ts` at repo root so the extension discovers all vitest projects (meerkat-node, meerkat-browser-runner, benchmarking)
- Configure `vitest.workspaceConfig` in VS Code settings

The jest-runner extension generates regex-based `-t` flags that vitest v1 does not support, causing all tests to be skipped when run from the IDE. The official vitest extension uses vitest's programmatic API instead.

## Test plan
- [ ] Install `vitest.explorer` extension in VS Code
- [ ] Uninstall/disable `firsttris.vscode-jest-runner`
- [ ] Reload VS Code and verify tests appear in the Testing panel
- [ ] Run tests from the Testing panel and confirm they execute

https://app.devrev.ai/devrev/issue/KERN-1376

🤖 Generated with [Claude Code](https://claude.com/claude-code)