### PR TITLE
fix(deps): bump axios to ^1.15.2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@swc/helpers": "~0.5.0",
         "@types/lodash.isnil": "^4.0.9",
         "apache-arrow": "^17.0.0",
-        "axios": "^1.15.0",
+        "axios": "^1.15.2",
         "dexie": "^3.2.4",
         "duckdb": "1.3.4",
         "express": "^4.21.2",
@@ -14863,9 +14863,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@swc/helpers": "~0.5.0",
     "@types/lodash.isnil": "^4.0.9",
     "apache-arrow": "^17.0.0",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "dexie": "^3.2.4",
     "duckdb": "1.3.4",
     "express": "^4.21.2",


### PR DESCRIPTION
## Summary
Bump `axios` from `1.15.0` → `1.15.2` to patch two critical Snyk CVEs.

## Connected Issues
- #ISS-295540
- #ISS-295541

## Craftsmanship, Integrity, and Devil's Advocacy
- [ ] Testing: Negative test cases: null or default values, crash and fault injection tests
- [ ] Testing: Boundary conditions: rolling upgrades, denial-of-service, etc.
- [ ] Testing: Fixing a few existing — flaky or permanently-broken — test cases
- [ ] Observing: Detailed error codes so machines can understand
- [ ] Observing: Adding superior metrics for future debugging
- [ ] Observing: Tracing the hairiest pathways for field serviceability
- [ ] Training: KnowledgeOps update? So AI always works.

## Story of the craft