### PR TITLE
feat(deps): upgrade @duckdb/duckdb-wasm to 1.32.0 (DuckDB core v1.4.3)

### DIFF
--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",
-    "@duckdb/duckdb-wasm": "1.29.1-dev266.0"
+    "@duckdb/duckdb-wasm": "1.32.0"
   },
   "scripts": {
     "release": "semantic-release"

--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.39",
   "dependencies": {
     "tslib": "^2.3.0",
-    "@duckdb/duckdb-wasm": "1.29.1-dev266.0",
+    "@duckdb/duckdb-wasm": "1.32.0",
     "dexie": "^3.2.4",
     "loglevel": "^1.8.1",
     "uuid": "^9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "1.29.1-dev266.0",
+        "@duckdb/duckdb-wasm": "1.32.0",
         "@duckdb/node-api": "1.1.3-alpha.7",
         "@swc/helpers": "~0.5.0",
         "@types/lodash.isnil": "^4.0.9",
@@ -2261,9 +2261,9 @@
       "license": "MIT"
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.29.1-dev266.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.1-dev266.0.tgz",
-      "integrity": "sha512-NsueqHFYdnsxHEXIqpRw4knQFV5iU/4//0MZtIPXPOdluBvxLe/iUtI9lLVE8ncC9tMFGM1+W1c3IiAF4imMZQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz",
+      "integrity": "sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==",
       "license": "MIT",
       "dependencies": {
         "apache-arrow": "^17.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {},
   "private": true,
   "dependencies": {
-    "@duckdb/duckdb-wasm": "1.29.1-dev266.0",
+    "@duckdb/duckdb-wasm": "1.32.0",
     "@duckdb/node-api": "1.1.3-alpha.7",
     "@swc/helpers": "~0.5.0",
     "@types/lodash.isnil": "^4.0.9",


### PR DESCRIPTION
## Summary

Upgrade `@duckdb/duckdb-wasm` from `1.29.1-dev266.0` to `1.32.0` (DuckDB core v1.4.3) across all WASM-dependent packages.

This aligns meerkat with:
- **Jarvis** node-api: already on DuckDB core v1.4.3 (PR [#208](https://github.com/devrev/jarvis/pull/208), merged Apr 11, released as v0.0.89)
- **devrev-web** WASM: PR [#47794](https://github.com/devrev/devrev-web/pull/47794) targeting `duckdb-wasm@1.32.0`

All three repos converge on **DuckDB core v1.4.3** for SOC2/ISO compliance ([ENH-6713](https://app.devrev.ai/devrev/works/ENH-6713)).

## Context

- A previous attempt (PR [#203](https://github.com/devrev/meerkat/pull/203)) targeted `duckdb-wasm@1.33.1-dev18.0` (a dev build) and was reverted (PR [#209](https://github.com/devrev/meerkat/pull/209)) due to [ISS-264300](https://app.devrev.ai/devrev/works/ISS-264300) — array values dropped on GROUP BY.
- This PR targets `1.32.0` (the **stable** release), not a dev build. This is a different WASM build than the one that was reverted.
- Widget SQL validation across 575,975 widgets (6 regions) showed **zero real DuckDB 1.4.3 regressions**.

## Changes

Pure dependency version bump — no code changes.

| File | Change |
|------|--------|
| `package.json` | `@duckdb/duckdb-wasm`: `1.29.1-dev266.0` → `1.32.0` |
| `meerkat-browser/package.json` | `@duckdb/duckdb-wasm`: `1.29.1-dev266.0` → `1.32.0` |
| `meerkat-dbm/package.json` | `@duckdb/duckdb-wasm`: `1.29.1-dev266.0` → `1.32.0` |
| `package-lock.json` | Regenerated |

## Test Results

All tests passing on the upgraded dependency:

| Package | Tests | Result |
|---------|-------|--------|
| meerkat-core | 507 (11 skipped) | ✅ PASS |
| meerkat-node | 887 | ✅ PASS |
| meerkat-browser | 2 | ✅ PASS |
| meerkat-dbm | 93 | ✅ PASS |
| **Total** | **1,489** | **✅ All pass** |

## Test plan

- [x] `npx nx test meerkat-core` — 507 passed
- [x] `npx nx test meerkat-node` — 887 passed
- [x] `npx nx test meerkat-browser` — 2 passed
- [x] `npx nx test meerkat-dbm` — 93 passed
- [ ] Verify GROUP BY on array columns works correctly (regression from ISS-264300)
- [ ] E2E testing in devrev-web with upgraded meerkat

## Reviewers

@vpbs2 @zaidjan-devrev — This is the meerkat piece of the DuckDB 1.4 upgrade. The previous attempt (#203 → dev build) was reverted due to GROUP BY array regression. This targets the stable `1.32.0` release instead. All 1,489 tests pass. Please review and flag any concerns about the GROUP BY behavior.

cc @senthilb-devrev

work-item: ISS-261015

🤖 Generated with [Claude Code](https://claude.com/claude-code)