### PR TITLE
perf: only alias schema members referenced by the query

### DIFF
--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-browser",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
+++ b/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
@@ -93,10 +93,10 @@ describe('ensureTableSchemasAlias', () => {
 
     expect(ensureColumnAliasBatch).toHaveBeenCalledWith({
       items: [
-        {
+        expect.objectContaining({
           sql: 'SUM(order_amount)',
           tableName: 'orders',
-        },
+        }),
       ],
       executeQuery: expect.any(Function),
     });

--- a/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
+++ b/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
@@ -1,5 +1,5 @@
 import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
-import type { TableSchema } from '@devrev/meerkat-core';
+import type { Query, TableSchema } from '@devrev/meerkat-core';
 
 jest.mock('@devrev/meerkat-core', () => ({
   ensureColumnAliasBatch: jest.fn(),
@@ -27,6 +27,10 @@ describe('ensureTableSchemasAlias', () => {
       dimensions: [],
     },
   ];
+
+  const query: Query = {
+    measures: ['orders.gross_amount'],
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -86,11 +90,21 @@ describe('ensureTableSchemasAlias', () => {
     const result = await ensureTableSchemasAlias({
       connection,
       tableSchemas,
+      query,
     });
 
     const ensureColumnAliasBatch =
       meerkatCore.ensureColumnAliasBatch as jest.Mock;
+    const ensureTableSchemaAliasSql =
+      meerkatCore.ensureTableSchemaAliasSql as jest.Mock;
 
+    expect(ensureTableSchemaAliasSql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableSchemas,
+        query,
+        ensureExpressionAlias: expect.any(Function),
+      })
+    );
     expect(ensureColumnAliasBatch).toHaveBeenCalledWith({
       items: [
         expect.objectContaining({
@@ -109,10 +123,13 @@ describe('ensureTableSchemasAlias', () => {
     } as unknown as AsyncDuckDBConnection;
     const factory = ensureTableSchemaAlias(connection);
 
-    await factory(tableSchemas);
+    await factory(tableSchemas, query);
 
     const ensureTableSchemaAliasSql =
       meerkatCore.ensureTableSchemaAliasSql as jest.Mock;
     expect(ensureTableSchemaAliasSql).toHaveBeenCalledTimes(1);
+    expect(ensureTableSchemaAliasSql).toHaveBeenCalledWith(
+      expect.objectContaining({ query })
+    );
   });
 });

--- a/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
+++ b/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
@@ -33,6 +33,7 @@ export const ensureTableSchemasAlias = async ({
         items: items.map((item) => ({
           sql: item.sql,
           tableName: item.context.tableName,
+          knownTableNames: item.context.knownTableNames,
         })),
         executeQuery,
       });

--- a/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
+++ b/meerkat-browser/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
@@ -1,6 +1,7 @@
 import { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
 import {
   GetQueryOutput,
+  Query,
   TableSchema,
   ensureColumnAliasBatch,
   ensureTableSchemaAliasSql,
@@ -17,17 +18,24 @@ const getQueryOutput = async (
 export interface EnsureTableSchemasAliasParams {
   connection: AsyncDuckDBConnection;
   tableSchemas: TableSchema[];
+  /**
+   * Query whose member references drive which members are aliased. Members
+   * that the query does not reach are passed through untouched.
+   */
+  query: Query;
 }
 
 export const ensureTableSchemasAlias = async ({
   connection,
   tableSchemas,
+  query,
 }: EnsureTableSchemasAliasParams): Promise<TableSchema[]> => {
-  const executeQuery: GetQueryOutput = (query) =>
-    getQueryOutput(query, connection);
+  const executeQuery: GetQueryOutput = (queryString) =>
+    getQueryOutput(queryString, connection);
 
   return ensureTableSchemaAliasSql({
     tableSchemas,
+    query,
     ensureExpressionAlias: async ({ items }) => {
       const aliasedItems = await ensureColumnAliasBatch({
         items: items.map((item) => ({
@@ -43,13 +51,15 @@ export const ensureTableSchemasAlias = async ({
   });
 };
 
-export const ensureTableSchemaAlias = (
-  connection: AsyncDuckDBConnection
-) => {
-  return async (tableSchemas: TableSchema[]): Promise<TableSchema[]> => {
+export const ensureTableSchemaAlias = (connection: AsyncDuckDBConnection) => {
+  return async (
+    tableSchemas: TableSchema[],
+    query: Query
+  ): Promise<TableSchema[]> => {
     return ensureTableSchemasAlias({
       connection,
       tableSchemas,
+      query,
     });
   };
 };

--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/meerkat-core/src/utils/__fixtures__/ensure-sql-expression-column-alias.fixtures.ts
+++ b/meerkat-core/src/utils/__fixtures__/ensure-sql-expression-column-alias.fixtures.ts
@@ -7,6 +7,7 @@ export interface EnsureColumnAliasScenario {
   expectedSql: string;
   shouldChange: boolean;
   notes?: string;
+  knownTableNames?: string[];
 }
 
 export interface DeferredEnsureColumnAliasScenario
@@ -157,6 +158,40 @@ export const ENSURE_COLUMN_ALIAS_SCENARIOS: EnsureColumnAliasScenario[] = [
     tableName: 'orders',
     inputSql: 'customers.id',
     expectedSql: 'customers.id',
+    shouldChange: false,
+  },
+  {
+    description: 'struct field access on local column is qualified',
+    tableName: 'issue',
+    knownTableNames: ['issue', 'devusers'],
+    inputSql: 'stage.stage_id',
+    expectedSql: 'issue.stage.stage_id',
+    shouldChange: true,
+  },
+  {
+    description:
+      'struct field access inside aggregate on local column is qualified',
+    tableName: 'issue',
+    knownTableNames: ['issue', 'devusers'],
+    inputSql: 'COUNT(stage.stage_id)',
+    expectedSql: 'COUNT(issue.stage.stage_id)',
+    shouldChange: true,
+  },
+  {
+    description:
+      'multi-part ref where leading identifier is another table stays untouched',
+    tableName: 'orders',
+    knownTableNames: ['orders', 'customers'],
+    inputSql: 'customers.id',
+    expectedSql: 'customers.id',
+    shouldChange: false,
+  },
+  {
+    description: 'already-qualified struct access is not double-qualified',
+    tableName: 'issue',
+    knownTableNames: ['issue'],
+    inputSql: 'issue.stage.stage_id',
+    expectedSql: 'issue.stage.stage_id',
     shouldChange: false,
   },
 ];

--- a/meerkat-core/src/utils/ensure-sql-expression-column-alias.spec.ts
+++ b/meerkat-core/src/utils/ensure-sql-expression-column-alias.spec.ts
@@ -328,6 +328,67 @@ const expressionAstBySql: Record<string, ParsedExpression> = {
   }),
   "'customer_id'": createStringConstant('customer_id'),
   '"Order ID"': createColumnRef('Order ID'),
+  'stage.stage_id': createColumnRef(['stage', 'stage_id']),
+  'issue.stage.stage_id': createColumnRef(['issue', 'stage', 'stage_id']),
+  'COUNT(stage.stage_id)': createFunction({
+    functionName: 'COUNT',
+    children: [createColumnRef(['stage', 'stage_id'])],
+  }),
+  'foo.bar': createColumnRef(['foo', 'bar']),
+  missing_column: createColumnRef('missing_column'),
+  'stage.stage_id + amount': createFunction({
+    functionName: '+',
+    children: [
+      createColumnRef(['stage', 'stage_id']),
+      createColumnRef('amount'),
+    ],
+    isOperator: true,
+  }),
+  'stage.stage_id = devusers.id': createComparison({
+    type: ExpressionType.COMPARE_EQUAL,
+    left: createColumnRef(['stage', 'stage_id']),
+    right: createColumnRef(['devusers', 'id']),
+  }),
+  'CASE WHEN stage.stage_id = 1 THEN owner.id END': createCase({
+    whenExpr: createComparison({
+      type: ExpressionType.COMPARE_EQUAL,
+      left: createColumnRef(['stage', 'stage_id']),
+      right: {
+        class: ExpressionClass.CONSTANT,
+        type: ExpressionType.VALUE_CONSTANT,
+        alias: '',
+        value: {
+          type: { id: 'INTEGER', type_info: null },
+          is_null: false,
+          value: 1,
+        },
+      } as ParsedExpression,
+    }),
+    thenExpr: createColumnRef(['owner', 'id']),
+    elseExpr: {
+      class: ExpressionClass.CONSTANT,
+      type: ExpressionType.VALUE_CONSTANT,
+      alias: '',
+      value: {
+        type: { id: 'NULL', type_info: null },
+        is_null: true,
+      },
+    } as ParsedExpression,
+  }),
+  'SUM(stage.stage_id)': createFunction({
+    functionName: 'SUM',
+    children: [createColumnRef(['stage', 'stage_id'])],
+  }),
+  'list_transform(stage.items, x -> x)': createFunction({
+    functionName: 'list_transform',
+    children: [
+      createColumnRef(['stage', 'items']),
+      createLambda({
+        lhs: createColumnRef('x'),
+        expr: createColumnRef('x'),
+      }),
+    ],
+  }),
   "list_transform(priority_tags, x -> CASE WHEN x = 1 THEN 'P1' ELSE 'Unknown' END)":
     createFunction({
       functionName: 'list_transform',
@@ -564,6 +625,241 @@ describe('column refs with quotes and dots are not re-aliased', () => {
   it('does not alias an already dot-qualified column ref from a different table', async () => {
     const result = await ensureSingleColumnAlias('customers.id', 'orders');
     expect(result).toBe('customers.id');
+  });
+});
+
+describe('schema-aware struct field aliasing', () => {
+  const runWithContext = async ({
+    sql,
+    tableName,
+    knownTableNames,
+  }: {
+    sql: string;
+    tableName: string;
+    knownTableNames?: string[];
+  }) => {
+    const [result] = await ensureColumnAliasBatch({
+      items: [
+        {
+          sql,
+          tableName,
+          knownTableNames: knownTableNames
+            ? new Set(knownTableNames)
+            : undefined,
+        },
+      ],
+      executeQuery: dummyGetQueryOutput,
+    });
+    if (!result) {
+      throw new Error('Missing alias result');
+    }
+    return result.sql;
+  };
+
+  it('qualifies struct field access on a local column', async () => {
+    const result = await runWithContext({
+      sql: 'stage.stage_id',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe('issue.stage.stage_id');
+  });
+
+  it('qualifies struct access inside an aggregate', async () => {
+    const result = await runWithContext({
+      sql: 'COUNT(stage.stage_id)',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe('COUNT(issue.stage.stage_id)');
+  });
+
+  it('leaves cross-table references to a known table alias untouched', async () => {
+    const result = await runWithContext({
+      sql: 'customers.id',
+      tableName: 'orders',
+      knownTableNames: ['orders', 'customers'],
+    });
+    expect(result).toBe('customers.id');
+  });
+
+  it('does not double-qualify already-qualified struct access', async () => {
+    const result = await runWithContext({
+      sql: 'issue.stage.stage_id',
+      tableName: 'issue',
+      knownTableNames: ['issue'],
+    });
+    expect(result).toBe('issue.stage.stage_id');
+  });
+
+  it('falls back to legacy behavior when knownTableNames is omitted', async () => {
+    const result = await runWithContext({
+      sql: 'customer_id',
+      tableName: 'orders',
+    });
+    expect(result).toBe('orders.customer_id');
+  });
+});
+
+describe('schema-aware struct aliasing — extended coverage', () => {
+  const run = async ({
+    sql,
+    tableName,
+    knownTableNames,
+  }: {
+    sql: string;
+    tableName: string;
+    knownTableNames?: string[];
+  }) => {
+    const [result] = await ensureColumnAliasBatch({
+      items: [
+        {
+          sql,
+          tableName,
+          knownTableNames: knownTableNames
+            ? new Set(knownTableNames)
+            : undefined,
+        },
+      ],
+      executeQuery: dummyGetQueryOutput,
+    });
+    return result?.sql;
+  };
+
+  it('qualifies struct access mixed with bare columns in arithmetic', async () => {
+    const result = await run({
+      sql: 'stage.stage_id + amount',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe('issue.stage.stage_id + issue.amount');
+  });
+
+  it('qualifies local struct but preserves cross-table ref in comparison', async () => {
+    const result = await run({
+      sql: 'stage.stage_id = devusers.id',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe('issue.stage.stage_id = devusers.id');
+  });
+
+  it('qualifies struct access inside CASE branches', async () => {
+    const result = await run({
+      sql: 'CASE WHEN stage.stage_id = 1 THEN owner.id END',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe(
+      'CASE WHEN issue.stage.stage_id = 1 THEN issue.owner.id END'
+    );
+  });
+
+  it('qualifies struct access inside SUM aggregate', async () => {
+    const result = await run({
+      sql: 'SUM(stage.stage_id)',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe('SUM(issue.stage.stage_id)');
+  });
+
+  it('qualifies struct access inside lambda function argument but not lambda-bound identifier', async () => {
+    const result = await run({
+      sql: 'list_transform(stage.items, x -> x)',
+      tableName: 'issue',
+      knownTableNames: ['issue', 'devusers'],
+    });
+    expect(result).toBe('LIST_TRANSFORM(issue.stage.items, x -> x)');
+  });
+
+  it('treats ambiguous multi-part ref as cross-table when knownTableNames contains root', async () => {
+    const result = await run({
+      sql: 'customers.id',
+      tableName: 'orders',
+      knownTableNames: ['orders', 'customers'],
+    });
+    expect(result).toBe('customers.id');
+  });
+
+  it('qualifies multi-part ref with unknown root as struct when schema batch is present', async () => {
+    const result = await run({
+      sql: 'foo.bar',
+      tableName: 'issue',
+      knownTableNames: ['issue'],
+    });
+    expect(result).toBe('issue.foo.bar');
+  });
+
+  it('stays conservative on multi-part ref when knownTableNames is omitted', async () => {
+    const result = await run({
+      sql: 'foo.bar',
+      tableName: 'issue',
+    });
+    expect(result).toBe('foo.bar');
+  });
+
+  it('does not double-qualify when root matches table even without knownTableNames', async () => {
+    const result = await run({
+      sql: 'orders.order_amount',
+      tableName: 'orders',
+    });
+    expect(result).toBe('orders.order_amount');
+  });
+});
+
+describe('ensureColumnAliasBatch — batched mixed tables', () => {
+  it('applies per-item knownTableNames correctly within a single batch', async () => {
+    const results = await ensureColumnAliasBatch({
+      items: [
+        {
+          sql: 'stage.stage_id',
+          tableName: 'issue',
+          knownTableNames: new Set(['issue', 'devusers']),
+        },
+        {
+          sql: 'customers.id',
+          tableName: 'orders',
+          knownTableNames: new Set(['orders', 'customers']),
+        },
+        {
+          sql: 'customer_id',
+          tableName: 'orders',
+        },
+      ],
+      executeQuery: dummyGetQueryOutput,
+    });
+
+    expect(results.map((r) => r.sql)).toEqual([
+      'issue.stage.stage_id',
+      'customers.id',
+      'orders.customer_id',
+    ]);
+    expect(results.map((r) => r.didChange)).toEqual([true, false, true]);
+  });
+
+  it('preserves context per-item through batched aliasing', async () => {
+    const results = await ensureColumnAliasBatch({
+      items: [
+        {
+          sql: 'customer_id',
+          tableName: 'orders',
+          context: { memberName: 'a' },
+        },
+        {
+          sql: 'stage.stage_id',
+          tableName: 'issue',
+          knownTableNames: new Set(['issue']),
+          context: { memberName: 'b' },
+        },
+      ],
+      executeQuery: dummyGetQueryOutput,
+    });
+
+    expect(results.map((r) => r.context)).toEqual([
+      { memberName: 'a' },
+      { memberName: 'b' },
+    ]);
   });
 });
 

--- a/meerkat-core/src/utils/ensure-sql-expression-column-alias.ts
+++ b/meerkat-core/src/utils/ensure-sql-expression-column-alias.ts
@@ -23,6 +23,12 @@ import { getChildExpressions } from './get-child-expressions';
 export interface EnsureColumnAliasBatchItem<TContext = unknown> {
   sql: string;
   tableName: string;
+  /**
+   * Names of all tables in the current schema batch. Used to distinguish a
+   * cross-table reference (e.g. `customers.id`) from struct field access
+   * (e.g. `stage.stage_id`) on multi-part column references.
+   */
+  knownTableNames?: Set<string>;
   context?: TContext;
 }
 
@@ -38,29 +44,56 @@ export interface EnsureColumnAliasBatchParams<TContext = unknown> {
 
 const ALIASABLE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+const isAliasableIdentifier = (identifier: string | undefined): boolean => {
+  if (!identifier) {
+    return false;
+  }
+  if (/\s/.test(identifier)) {
+    return false;
+  }
+  return ALIASABLE_IDENTIFIER_REGEX.test(identifier);
+};
+
 const shouldEnsureColumnRefAlias = (
   columnNames: string[],
-  scopedIdentifiers: Set<string>
+  scopedIdentifiers: Set<string>,
+  tableName: string,
+  knownTableNames?: Set<string>
 ): boolean => {
-  if (columnNames.length !== 1) {
+  if (columnNames.length === 0) {
     return false;
   }
 
-  const [columnName] = columnNames;
+  const [root] = columnNames;
 
-  if (!columnName) {
+  if (!isAliasableIdentifier(root)) {
     return false;
   }
 
-  if (/\s/.test(columnName)) {
+  if (scopedIdentifiers.has(root)) {
     return false;
   }
 
-  if (scopedIdentifiers.has(columnName)) {
-    return false;
+  if (columnNames.length === 1) {
+    return true;
   }
 
-  return ALIASABLE_IDENTIFIER_REGEX.test(columnName);
+  if (columnNames.length === 2) {
+    if (root === tableName) {
+      return false;
+    }
+    // Without a schema batch, a two-part ref is ambiguous between
+    // `table.column` and `struct.field`; stay conservative.
+    if (!knownTableNames) {
+      return false;
+    }
+    if (knownTableNames.has(root)) {
+      return false;
+    }
+    return true;
+  }
+
+  return false;
 };
 
 const getLambdaBoundIdentifiers = (
@@ -84,14 +117,16 @@ const getLambdaBoundIdentifiers = (
 const ensureOrderByNodesAlias = (
   orders: OrderByNode[],
   scopedIdentifiers: Set<string>,
-  tableName?: string
+  tableName?: string,
+  knownTableNames?: Set<string>
 ): boolean => {
   return orders.reduce(
     (changed, order) =>
       ensureParsedExpressionAlias(
         order.expression,
         tableName,
-        scopedIdentifiers
+        scopedIdentifiers,
+        knownTableNames
       ) || changed,
     false
   );
@@ -124,7 +159,8 @@ const isLimitLikeModifier = (
 const ensureQueryNodeAlias = (
   node: QueryNode,
   tableName?: string,
-  scopedIdentifiers: Set<string> = new Set()
+  scopedIdentifiers: Set<string> = new Set(),
+  knownTableNames?: Set<string>
 ): boolean => {
   if (isSelectNode(node)) {
     let changed = false;
@@ -134,7 +170,8 @@ const ensureQueryNodeAlias = (
         ensureParsedExpressionAlias(
           expression,
           tableName,
-          scopedIdentifiers
+          scopedIdentifiers,
+          knownTableNames
         ) || changed;
     });
     changed =
@@ -142,7 +179,8 @@ const ensureQueryNodeAlias = (
         ? ensureParsedExpressionAlias(
             node.where_clause,
             tableName,
-            scopedIdentifiers
+            scopedIdentifiers,
+            knownTableNames
           )
         : false) || changed;
     node.group_expressions.forEach((expression) => {
@@ -150,7 +188,8 @@ const ensureQueryNodeAlias = (
         ensureParsedExpressionAlias(
           expression,
           tableName,
-          scopedIdentifiers
+          scopedIdentifiers,
+          knownTableNames
         ) || changed;
     });
     changed =
@@ -158,7 +197,8 @@ const ensureQueryNodeAlias = (
         ? ensureParsedExpressionAlias(
             node.having,
             tableName,
-            scopedIdentifiers
+            scopedIdentifiers,
+            knownTableNames
           )
         : false) || changed;
     changed =
@@ -166,7 +206,8 @@ const ensureQueryNodeAlias = (
         ? ensureParsedExpressionAlias(
             node.qualify,
             tableName,
-            scopedIdentifiers
+            scopedIdentifiers,
+            knownTableNames
           )
         : false) || changed;
 
@@ -176,7 +217,8 @@ const ensureQueryNodeAlias = (
           ensureOrderByNodesAlias(
             modifier.orders,
             scopedIdentifiers,
-            tableName
+            tableName,
+            knownTableNames
           ) || changed;
       }
 
@@ -187,7 +229,8 @@ const ensureQueryNodeAlias = (
               ensureParsedExpressionAlias(
                 target,
                 tableName,
-                scopedIdentifiers
+                scopedIdentifiers,
+                knownTableNames
               ) || changed)
         );
       }
@@ -198,7 +241,8 @@ const ensureQueryNodeAlias = (
             ? ensureParsedExpressionAlias(
                 modifier.limit,
                 tableName,
-                scopedIdentifiers
+                scopedIdentifiers,
+                knownTableNames
               )
             : false) || changed;
         changed =
@@ -206,7 +250,8 @@ const ensureQueryNodeAlias = (
             ? ensureParsedExpressionAlias(
                 modifier.offset,
                 tableName,
-                scopedIdentifiers
+                scopedIdentifiers,
+                knownTableNames
               )
             : false) || changed;
       }
@@ -218,27 +263,57 @@ const ensureQueryNodeAlias = (
   if (node.type === QueryNodeType.SET_OPERATION_NODE) {
     let changed = false;
     changed =
-      ensureQueryNodeAlias(node.left, tableName, scopedIdentifiers) || changed;
+      ensureQueryNodeAlias(
+        node.left,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed;
     changed =
-      ensureQueryNodeAlias(node.right, tableName, scopedIdentifiers) || changed;
+      ensureQueryNodeAlias(
+        node.right,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed;
     return changed;
   }
 
   if (node.type === QueryNodeType.RECURSIVE_CTE_NODE) {
     let changed = false;
     changed =
-      ensureQueryNodeAlias(node.left, tableName, scopedIdentifiers) || changed;
+      ensureQueryNodeAlias(
+        node.left,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed;
     changed =
-      ensureQueryNodeAlias(node.right, tableName, scopedIdentifiers) || changed;
+      ensureQueryNodeAlias(
+        node.right,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed;
     return changed;
   }
 
   if (node.type === QueryNodeType.CTE_NODE) {
     let changed = false;
     changed =
-      ensureQueryNodeAlias(node.query, tableName, scopedIdentifiers) || changed;
+      ensureQueryNodeAlias(
+        node.query,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed;
     changed =
-      ensureQueryNodeAlias(node.child, tableName, scopedIdentifiers) || changed;
+      ensureQueryNodeAlias(
+        node.child,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed;
     return changed;
   }
 
@@ -248,15 +323,23 @@ const ensureQueryNodeAlias = (
 const ensureParsedExpressionAlias = (
   node: ParsedExpression,
   tableName?: string,
-  scopedIdentifiers: Set<string> = new Set()
+  scopedIdentifiers: Set<string> = new Set(),
+  knownTableNames?: Set<string>
 ): boolean => {
   if (!node || !tableName) {
     return false;
   }
 
   if (isColumnRefExpression(node)) {
-    if (shouldEnsureColumnRefAlias(node.column_names, scopedIdentifiers)) {
-      node.column_names = [tableName, node.column_names[0]];
+    if (
+      shouldEnsureColumnRefAlias(
+        node.column_names,
+        scopedIdentifiers,
+        tableName,
+        knownTableNames
+      )
+    ) {
+      node.column_names = [tableName, ...node.column_names];
       return true;
     }
     return false;
@@ -272,7 +355,8 @@ const ensureParsedExpressionAlias = (
       ? ensureParsedExpressionAlias(
           node.expr,
           tableName,
-          lambdaScopedIdentifiers
+          lambdaScopedIdentifiers,
+          knownTableNames
         )
       : false;
   }
@@ -281,14 +365,16 @@ const ensureParsedExpressionAlias = (
     let changed = ensureQueryNodeAlias(
       node.subquery.node,
       tableName,
-      scopedIdentifiers
+      scopedIdentifiers,
+      knownTableNames
     );
     if (node.child) {
       changed =
         ensureParsedExpressionAlias(
           node.child,
           tableName,
-          scopedIdentifiers
+          scopedIdentifiers,
+          knownTableNames
         ) || changed;
     }
     return changed;
@@ -296,8 +382,12 @@ const ensureParsedExpressionAlias = (
 
   return getChildExpressions(node).reduce(
     (changed, child) =>
-      ensureParsedExpressionAlias(child, tableName, scopedIdentifiers) ||
-      changed,
+      ensureParsedExpressionAlias(
+        child,
+        tableName,
+        scopedIdentifiers,
+        knownTableNames
+      ) || changed,
     false
   );
 };
@@ -336,7 +426,9 @@ export const ensureColumnAliasBatch = async <TContext = unknown>({
   parsedExpressions.forEach((parsedExpression, index) => {
     const didChange = ensureParsedExpressionAlias(
       parsedExpression,
-      items[index].tableName
+      items[index].tableName,
+      new Set(),
+      items[index].knownTableNames
     );
     if (!didChange) {
       return;

--- a/meerkat-core/src/utils/ensure-table-schema-alias-sql.spec.ts
+++ b/meerkat-core/src/utils/ensure-table-schema-alias-sql.spec.ts
@@ -88,14 +88,14 @@ describe('ensureTableSchemaAliasSql', () => {
     expect(ensureExpressionAlias).toHaveBeenCalledTimes(2);
     expect(ensureExpressionAlias).toHaveBeenCalledWith({
       items: expect.arrayContaining([
-        {
+        expect.objectContaining({
           sql: 'SUM(order_amount)',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'gross_amount',
             memberType: 'measure',
-          },
-        },
+          }),
+        }),
       ]),
     });
   });
@@ -220,38 +220,38 @@ describe('ensureTableSchemaAliasSql', () => {
     expect(ensureExpressionAlias).toHaveBeenCalledTimes(2);
     expect(ensureExpressionAlias).toHaveBeenNthCalledWith(1, {
       items: [
-        {
+        expect.objectContaining({
           sql: 'SUM(order_amount)',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'gross_amount',
             memberType: 'measure',
-          },
-        },
-        {
+          }),
+        }),
+        expect.objectContaining({
           sql: 'SUM(order_amount - discount_amount)',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'net_amount',
             memberType: 'measure',
-          },
-        },
-        {
+          }),
+        }),
+        expect.objectContaining({
           sql: 'customer_id',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'customer_id',
             memberType: 'dimension',
-          },
-        },
-        {
+          }),
+        }),
+        expect.objectContaining({
           sql: "DATE_TRUNC('month', created_at)",
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'order_month',
             memberType: 'dimension',
-          },
-        },
+          }),
+        }),
       ],
     });
     expect(result[0].measures.map((measure) => measure.sql)).toEqual([
@@ -284,39 +284,145 @@ describe('ensureTableSchemaAliasSql', () => {
     expect(ensureExpressionAlias).toHaveBeenCalled();
     expect(ensureExpressionAlias).toHaveBeenCalledWith({
       items: [
-        {
+        expect.objectContaining({
           sql: 'SUM(order_amount)',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'gross_amount',
             memberType: 'measure',
-          },
-        },
-        {
+          }),
+        }),
+        expect.objectContaining({
           sql: 'SUM(order_amount - discount_amount)',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'net_amount',
             memberType: 'measure',
-          },
-        },
-        {
+          }),
+        }),
+        expect.objectContaining({
           sql: 'customer_id',
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'customer_id',
             memberType: 'dimension',
-          },
-        },
-        {
+          }),
+        }),
+        expect.objectContaining({
           sql: "DATE_TRUNC('month', created_at)",
-          context: {
+          context: expect.objectContaining({
             tableName: 'orders',
             memberName: 'order_month',
             memberType: 'dimension',
-          },
-        },
+          }),
+        }),
       ],
     });
+  });
+
+  it('threads knownTableNames through the expression aliaser', async () => {
+    const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+    const ensureExpressionAlias = jest.fn(async ({ items }) =>
+      items.map(({ sql }: { sql: string }) => sql)
+    );
+
+    await ensureTableSchemaAliasSql({
+      tableSchemas,
+      ensureExpressionAlias,
+    });
+
+    const [firstCallArgs] = ensureExpressionAlias.mock.calls;
+    const [{ items: ordersItems }] = firstCallArgs;
+    expect(ordersItems[0].context.knownTableNames).toEqual(
+      new Set(['orders', 'customers'])
+    );
+  });
+
+  it('passes the same knownTableNames to every table in the batch', async () => {
+    const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+    const ensureExpressionAlias = jest.fn(async ({ items }) =>
+      items.map(({ sql }: { sql: string }) => sql)
+    );
+
+    await ensureTableSchemaAliasSql({
+      tableSchemas,
+      ensureExpressionAlias,
+    });
+
+    const expected = new Set(['orders', 'customers']);
+    for (const [call] of ensureExpressionAlias.mock.calls) {
+      for (const item of call.items) {
+        expect(item.context.knownTableNames).toEqual(expected);
+      }
+    }
+  });
+
+  it('uses a knownTableNames set derived from all provided schemas', async () => {
+    const schemas = [
+      ...createEnsureTableSchemaAliasSqlFixture(),
+      {
+        name: 'audit',
+        sql: 'SELECT * FROM audit',
+        measures: [
+          { name: 'total', sql: 'COUNT(id)', type: 'number' as const },
+        ],
+        dimensions: [],
+      },
+    ];
+    const ensureExpressionAlias = jest.fn(async ({ items }) =>
+      items.map(({ sql }: { sql: string }) => sql)
+    );
+
+    await ensureTableSchemaAliasSql({
+      tableSchemas: schemas,
+      ensureExpressionAlias,
+    });
+
+    const expected = new Set(['orders', 'customers', 'audit']);
+    const lastCall =
+      ensureExpressionAlias.mock.calls[
+        ensureExpressionAlias.mock.calls.length - 1
+      ][0];
+    expect(lastCall.items[0].context.knownTableNames).toEqual(expected);
+  });
+
+  it('does not mutate measures/dimensions when ensureExpressionAlias is a no-op', async () => {
+    const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+    const before = JSON.parse(JSON.stringify(tableSchemas));
+
+    const result = await ensureTableSchemaAliasSql({
+      tableSchemas,
+      ensureExpressionAlias: async ({ items }) =>
+        items.map(({ sql }: { sql: string }) => sql),
+    });
+
+    expect(tableSchemas).toEqual(before);
+    expect(result[0].measures[0].sql).toBe(
+      tableSchemas[0].measures[0].sql
+    );
+    expect(result[0]).not.toBe(tableSchemas[0]);
+    expect(result[0].measures).not.toBe(tableSchemas[0].measures);
+  });
+
+  it('handles schema with no measures or dimensions without calling aliaser', async () => {
+    const schemas = [
+      {
+        name: 'empty',
+        sql: 'SELECT 1',
+        measures: [],
+        dimensions: [],
+      },
+    ];
+    const ensureExpressionAlias = jest.fn(async ({ items }) =>
+      items.map(({ sql }: { sql: string }) => sql)
+    );
+
+    const result = await ensureTableSchemaAliasSql({
+      tableSchemas: schemas,
+      ensureExpressionAlias,
+    });
+
+    expect(ensureExpressionAlias).not.toHaveBeenCalled();
+    expect(result).toEqual(schemas);
   });
 });

--- a/meerkat-core/src/utils/ensure-table-schema-alias-sql.spec.ts
+++ b/meerkat-core/src/utils/ensure-table-schema-alias-sql.spec.ts
@@ -1,8 +1,18 @@
+import { Query } from '../types/cube-types';
 import { createEnsureTableSchemaAliasSqlFixture } from './__fixtures__/ensure-sql-expression-column-alias.fixtures';
 import {
   EnsureAliasExpressionContext,
   ensureTableSchemaAliasSql,
 } from './ensure-table-schema-alias-sql';
+
+const FULL_FIXTURE_QUERY: Query = {
+  measures: [
+    'orders.gross_amount',
+    'orders.net_amount',
+    'customers.gross_amount',
+  ],
+  dimensions: ['orders.customer_id', 'orders.order_month', 'customers.id'],
+};
 
 describe('ensureTableSchemaAliasSql', () => {
   it('rewrites measure and dimension SQL while preserving schema-level SQL and joins', async () => {
@@ -34,6 +44,7 @@ describe('ensureTableSchemaAliasSql', () => {
 
     const result = await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: FULL_FIXTURE_QUERY,
       ensureExpressionAlias,
     });
 
@@ -106,6 +117,7 @@ describe('ensureTableSchemaAliasSql', () => {
 
     await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: FULL_FIXTURE_QUERY,
       ensureExpressionAlias: async ({ items }) =>
         items.map(({ sql }: { sql: string }) => `mockAliased:${sql}`),
     });
@@ -119,6 +131,7 @@ describe('ensureTableSchemaAliasSql', () => {
     await expect(
       ensureTableSchemaAliasSql({
         tableSchemas,
+        query: FULL_FIXTURE_QUERY,
         ensureExpressionAlias: async ({ items }) =>
           items.map(
             ({ context }: { context: EnsureAliasExpressionContext }) => {
@@ -164,6 +177,10 @@ describe('ensureTableSchemaAliasSql', () => {
 
     const result = await ensureTableSchemaAliasSql({
       tableSchemas: placeholderSchemas,
+      query: {
+        measures: ['orders.gross_amount', 'orders.placeholder_measure'],
+        dimensions: ['orders.customer_id', 'orders.placeholder_dimension'],
+      },
       ensureExpressionAlias,
     });
 
@@ -214,6 +231,7 @@ describe('ensureTableSchemaAliasSql', () => {
 
     const result = await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: FULL_FIXTURE_QUERY,
       ensureExpressionAlias,
     });
 
@@ -275,6 +293,7 @@ describe('ensureTableSchemaAliasSql', () => {
     await expect(
       ensureTableSchemaAliasSql({
         tableSchemas,
+        query: FULL_FIXTURE_QUERY,
         ensureExpressionAlias,
       })
     ).rejects.toThrow(
@@ -328,6 +347,7 @@ describe('ensureTableSchemaAliasSql', () => {
 
     await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: FULL_FIXTURE_QUERY,
       ensureExpressionAlias,
     });
 
@@ -346,6 +366,7 @@ describe('ensureTableSchemaAliasSql', () => {
 
     await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: FULL_FIXTURE_QUERY,
       ensureExpressionAlias,
     });
 
@@ -375,6 +396,10 @@ describe('ensureTableSchemaAliasSql', () => {
 
     await ensureTableSchemaAliasSql({
       tableSchemas: schemas,
+      query: {
+        ...FULL_FIXTURE_QUERY,
+        measures: [...FULL_FIXTURE_QUERY.measures, 'audit.total'],
+      },
       ensureExpressionAlias,
     });
 
@@ -392,6 +417,7 @@ describe('ensureTableSchemaAliasSql', () => {
 
     const result = await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: FULL_FIXTURE_QUERY,
       ensureExpressionAlias: async ({ items }) =>
         items.map(({ sql }: { sql: string }) => sql),
     });
@@ -419,10 +445,167 @@ describe('ensureTableSchemaAliasSql', () => {
 
     const result = await ensureTableSchemaAliasSql({
       tableSchemas: schemas,
+      query: { measures: [] },
       ensureExpressionAlias,
     });
 
     expect(ensureExpressionAlias).not.toHaveBeenCalled();
     expect(result).toEqual(schemas);
+  });
+
+  describe('query-driven filtering', () => {
+    it('skips members that the query does not reference', async () => {
+      const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+      const ensureExpressionAlias = jest.fn(async ({ items }) =>
+        items.map(
+          ({ context }: { context: EnsureAliasExpressionContext }) =>
+            `aliased(${context.tableName}.${context.memberName})`
+        )
+      );
+
+      const result = await ensureTableSchemaAliasSql({
+        tableSchemas,
+        query: {
+          measures: ['orders.gross_amount'],
+          dimensions: ['orders.customer_id'],
+        },
+        ensureExpressionAlias,
+      });
+
+      expect(ensureExpressionAlias).toHaveBeenCalledTimes(1);
+      const [{ items }] = ensureExpressionAlias.mock.calls[0];
+      expect(items).toHaveLength(2);
+      expect(items.map((item: { context: EnsureAliasExpressionContext }) =>
+        `${item.context.tableName}.${item.context.memberName}`
+      )).toEqual(['orders.gross_amount', 'orders.customer_id']);
+
+      expect(result[0].measures[0].sql).toBe('aliased(orders.gross_amount)');
+      expect(result[0].measures[1].sql).toBe(
+        tableSchemas[0].measures[1].sql
+      );
+      expect(result[0].dimensions[0].sql).toBe(
+        'aliased(orders.customer_id)'
+      );
+      expect(result[0].dimensions[1].sql).toBe(
+        tableSchemas[0].dimensions[1].sql
+      );
+      expect(result[1].measures[0].sql).toBe(
+        tableSchemas[1].measures[0].sql
+      );
+      expect(result[1].dimensions[0].sql).toBe(
+        tableSchemas[1].dimensions[0].sql
+      );
+    });
+
+    it('includes members referenced only by filters', async () => {
+      const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+      const ensureExpressionAlias = jest.fn(async ({ items }) =>
+        items.map(({ sql }: { sql: string }) => sql)
+      );
+
+      await ensureTableSchemaAliasSql({
+        tableSchemas,
+        query: {
+          measures: [],
+          filters: [
+            {
+              and: [
+                {
+                  member: 'orders.customer_id',
+                  operator: 'equals',
+                  values: ['42'],
+                },
+                {
+                  or: [
+                    {
+                      member: 'customers.id',
+                      operator: 'equals',
+                      values: ['42'],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        ensureExpressionAlias,
+      });
+
+      const referencedMembers = ensureExpressionAlias.mock.calls
+        .flatMap(([{ items }]) => items)
+        .map(
+          (item: { context: EnsureAliasExpressionContext }) =>
+            `${item.context.tableName}.${item.context.memberName}`
+        );
+      expect(referencedMembers.sort()).toEqual(
+        ['orders.customer_id', 'customers.id'].sort()
+      );
+    });
+
+    it('includes members referenced only by order', async () => {
+      const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+      const ensureExpressionAlias = jest.fn(async ({ items }) =>
+        items.map(({ sql }: { sql: string }) => sql)
+      );
+
+      await ensureTableSchemaAliasSql({
+        tableSchemas,
+        query: {
+          measures: [],
+          order: {
+            'orders.order_month': 'desc',
+          },
+        },
+        ensureExpressionAlias,
+      });
+
+      const referencedMembers = ensureExpressionAlias.mock.calls
+        .flatMap(([{ items }]) => items)
+        .map(
+          (item: { context: EnsureAliasExpressionContext }) =>
+            `${item.context.tableName}.${item.context.memberName}`
+        );
+      expect(referencedMembers).toEqual(['orders.order_month']);
+    });
+
+    it('ignores joinPaths entries because they reference table names, not members', async () => {
+      const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+      const ensureExpressionAlias = jest.fn(async ({ items }) =>
+        items.map(({ sql }: { sql: string }) => sql)
+      );
+
+      await ensureTableSchemaAliasSql({
+        tableSchemas,
+        query: {
+          measures: [],
+          joinPaths: [
+            [
+              {
+                left: 'orders',
+                right: 'customers',
+                on: 'customer_id',
+              },
+            ],
+          ],
+        },
+        ensureExpressionAlias,
+      });
+
+      expect(ensureExpressionAlias).not.toHaveBeenCalled();
+    });
+
+    it('does not call aliaser when query references no schema members', async () => {
+      const tableSchemas = createEnsureTableSchemaAliasSqlFixture();
+      const ensureExpressionAlias = jest.fn();
+
+      const result = await ensureTableSchemaAliasSql({
+        tableSchemas,
+        query: { measures: [] },
+        ensureExpressionAlias,
+      });
+
+      expect(ensureExpressionAlias).not.toHaveBeenCalled();
+      expect(result).toEqual(tableSchemas);
+    });
   });
 });

--- a/meerkat-core/src/utils/ensure-table-schema-alias-sql.ts
+++ b/meerkat-core/src/utils/ensure-table-schema-alias-sql.ts
@@ -7,6 +7,12 @@ export interface EnsureAliasExpressionContext {
   tableName: string;
   memberName: string;
   memberType: MemberType;
+  /**
+   * Names of all tables in the current schema batch. Used to treat
+   * `otherTable.col` as an intentional cross-table reference rather than a
+   * struct access.
+   */
+  knownTableNames?: Set<string>;
 }
 
 export interface EnsureTableSchemaAliasSqlParams {
@@ -29,11 +35,13 @@ const collectAliasableDescriptors = ({
   members,
   memberType,
   tableName,
+  knownTableNames,
   descriptors,
 }: {
   members: AliasableMember[];
   memberType: MemberType;
   tableName: string;
+  knownTableNames?: Set<string>;
   descriptors: AliasableMemberDescriptor[];
 }): void => {
   members.forEach((member) => {
@@ -43,6 +51,7 @@ const collectAliasableDescriptors = ({
         tableName,
         memberName: member.name,
         memberType,
+        knownTableNames,
       },
       apply: (aliasedSql: string) => {
         member.sql = aliasedSql;
@@ -93,6 +102,8 @@ export const ensureTableSchemaAliasSql = async ({
   tableSchemas,
   ensureExpressionAlias,
 }: EnsureTableSchemaAliasSqlParams): Promise<TableSchema[]> => {
+  const knownTableNames = new Set(tableSchemas.map((s) => s.name));
+
   return Promise.all(
     tableSchemas.map(async (tableSchema) => {
       const aliasedTableSchema: TableSchema = {
@@ -108,12 +119,14 @@ export const ensureTableSchemaAliasSql = async ({
         members: aliasedTableSchema.measures,
         memberType: 'measure',
         tableName: tableSchema.name,
+        knownTableNames,
         descriptors,
       });
       collectAliasableDescriptors({
         members: aliasedTableSchema.dimensions,
         memberType: 'dimension',
         tableName: tableSchema.name,
+        knownTableNames,
         descriptors,
       });
 

--- a/meerkat-core/src/utils/ensure-table-schema-alias-sql.ts
+++ b/meerkat-core/src/utils/ensure-table-schema-alias-sql.ts
@@ -1,4 +1,9 @@
-import { Dimension, Measure, TableSchema } from '../types/cube-types';
+import {
+  Dimension,
+  Measure,
+  Query,
+  TableSchema,
+} from '../types/cube-types';
 
 export type AliasableMember = Measure | Dimension;
 type MemberType = 'measure' | 'dimension';
@@ -17,6 +22,13 @@ export interface EnsureAliasExpressionContext {
 
 export interface EnsureTableSchemaAliasSqlParams {
   tableSchemas: TableSchema[];
+  /**
+   * Query whose member references drive which table-schema members are
+   * aliased. Members that the query does not reach are left untouched and
+   * never sent through `ensureExpressionAlias` — this is the primary
+   * optimization when tenants have thousands of dimensions.
+   */
+  query: Query;
   ensureExpressionAlias: (params: {
     items: {
       sql: string;
@@ -31,20 +43,62 @@ interface AliasableMemberDescriptor {
   apply: (aliasedSql: string) => void;
 }
 
+const collectFilterMembers = (filter: unknown, acc: Set<string>): void => {
+  if (!filter || typeof filter !== 'object') {
+    return;
+  }
+  const candidate = filter as {
+    and?: unknown[];
+    or?: unknown[];
+    member?: string;
+  };
+  if (Array.isArray(candidate.and)) {
+    candidate.and.forEach((child) => collectFilterMembers(child, acc));
+    return;
+  }
+  if (Array.isArray(candidate.or)) {
+    candidate.or.forEach((child) => collectFilterMembers(child, acc));
+    return;
+  }
+  if (typeof candidate.member === 'string') {
+    acc.add(candidate.member);
+  }
+};
+
+const collectReferencedMembers = (query: Query): Set<string> => {
+  const referenced = new Set<string>();
+
+  query.measures.forEach((m) => referenced.add(m));
+  query.dimensions?.forEach((d) => referenced.add(d));
+
+  if (query.order) {
+    Object.keys(query.order).forEach((m) => referenced.add(m));
+  }
+
+  query.filters?.forEach((filter) => collectFilterMembers(filter, referenced));
+
+  return referenced;
+};
+
 const collectAliasableDescriptors = ({
   members,
   memberType,
   tableName,
   knownTableNames,
+  referencedMembers,
   descriptors,
 }: {
   members: AliasableMember[];
   memberType: MemberType;
   tableName: string;
   knownTableNames?: Set<string>;
+  referencedMembers: Set<string>;
   descriptors: AliasableMemberDescriptor[];
 }): void => {
   members.forEach((member) => {
+    if (!referencedMembers.has(`${tableName}.${member.name}`)) {
+      return;
+    }
     descriptors.push({
       sql: member.sql,
       context: {
@@ -100,9 +154,11 @@ const ensureDescriptorBatchAlias = async ({
 
 export const ensureTableSchemaAliasSql = async ({
   tableSchemas,
+  query,
   ensureExpressionAlias,
 }: EnsureTableSchemaAliasSqlParams): Promise<TableSchema[]> => {
   const knownTableNames = new Set(tableSchemas.map((s) => s.name));
+  const referencedMembers = collectReferencedMembers(query);
 
   return Promise.all(
     tableSchemas.map(async (tableSchema) => {
@@ -120,6 +176,7 @@ export const ensureTableSchemaAliasSql = async ({
         memberType: 'measure',
         tableName: tableSchema.name,
         knownTableNames,
+        referencedMembers,
         descriptors,
       });
       collectAliasableDescriptors({
@@ -127,6 +184,7 @@ export const ensureTableSchemaAliasSql = async ({
         memberType: 'dimension',
         tableName: tableSchema.name,
         knownTableNames,
+        referencedMembers,
         descriptors,
       });
 

--- a/meerkat-node/package.json
+++ b/meerkat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-node",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "dependencies": {
     "@swc/helpers": "~0.5.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-node/src/__tests__/ensure-sql-expression-column-alias.spec.ts
+++ b/meerkat-node/src/__tests__/ensure-sql-expression-column-alias.spec.ts
@@ -177,6 +177,18 @@ describe('ensureTableSchemaAliasSql integration', () => {
 
     const aliasedSchemas = await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: {
+        measures: [
+          'orders.total_amount',
+          'orders.conditional_amount',
+          'orders.blended_amount',
+        ],
+        dimensions: [
+          'orders.order_month',
+          'orders.customer_id',
+          'orders.order_health',
+        ],
+      },
       ensureExpressionAlias: async ({ items }) => {
         const aliasedItems = await ensureColumnAliasBatch({
           items: items.map((item) => ({
@@ -253,6 +265,10 @@ describe('ensureTableSchemaAliasSql integration', () => {
 
     const aliasedSchemas = await ensureTableSchemaAliasSql({
       tableSchemas,
+      query: {
+        measures: ['orders.blended_amount', 'orders.between_amount'],
+        dimensions: ['orders.order_health', 'orders.order_month'],
+      },
       ensureExpressionAlias: async ({ items }) => {
         const aliasedItems = await ensureColumnAliasBatch({
           items: items.map((item) => ({

--- a/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
+++ b/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
@@ -89,16 +89,18 @@ describe('ensureTableSchemasAlias', () => {
   it('ensures alias for schemas using duckdbExec plumbing', async () => {
     const result = await ensureTableSchemasAlias(tableSchemas);
 
-    expect(ensureTableSchemaAliasSql).toHaveBeenCalledWith({
-      tableSchemas,
-      ensureExpressionAlias: expect.any(Function),
-    });
+    expect(ensureTableSchemaAliasSql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableSchemas,
+        ensureExpressionAlias: expect.any(Function),
+      })
+    );
     expect(ensureColumnAliasBatch).toHaveBeenCalledWith({
       items: [
-        {
+        expect.objectContaining({
           sql: 'SUM(order_amount)',
           tableName: 'orders',
-        },
+        }),
       ],
       executeQuery: expect.any(Function),
     });

--- a/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
+++ b/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.spec.ts
@@ -1,4 +1,4 @@
-import type { TableSchema } from '@devrev/meerkat-core';
+import type { Query, TableSchema } from '@devrev/meerkat-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
@@ -47,6 +47,11 @@ describe('ensureTableSchemasAlias', () => {
     },
   ];
 
+  const query: Query = {
+    measures: ['orders.gross_amount'],
+    dimensions: ['orders.customer_id'],
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     ensureColumnAliasBatch.mockResolvedValue([
@@ -87,11 +92,12 @@ describe('ensureTableSchemasAlias', () => {
   });
 
   it('ensures alias for schemas using duckdbExec plumbing', async () => {
-    const result = await ensureTableSchemasAlias(tableSchemas);
+    const result = await ensureTableSchemasAlias({ tableSchemas, query });
 
     expect(ensureTableSchemaAliasSql).toHaveBeenCalledWith(
       expect.objectContaining({
         tableSchemas,
+        query,
         ensureExpressionAlias: expect.any(Function),
       })
     );
@@ -109,9 +115,12 @@ describe('ensureTableSchemasAlias', () => {
 
   it('returns a reusable factory', async () => {
     const factory = ensureTableSchemaAlias();
-    const result = await factory(tableSchemas);
+    const result = await factory(tableSchemas, query);
 
     expect(ensureTableSchemaAliasSql).toHaveBeenCalledTimes(1);
+    expect(ensureTableSchemaAliasSql).toHaveBeenCalledWith(
+      expect.objectContaining({ query })
+    );
     expect(result).toHaveLength(1);
   });
 });

--- a/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
+++ b/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
@@ -15,6 +15,7 @@ export const ensureTableSchemasAlias = async (
         items: items.map((item) => ({
           sql: item.sql,
           tableName: item.context.tableName,
+          knownTableNames: item.context.knownTableNames,
         })),
         executeQuery: (query) =>
           duckdbExec<Record<string, string>[]>(query),

--- a/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
+++ b/meerkat-node/src/ensure-table-schema-alias/ensure-table-schema-alias.ts
@@ -1,15 +1,27 @@
 import {
+  Query,
   TableSchema,
   ensureColumnAliasBatch,
   ensureTableSchemaAliasSql,
 } from '@devrev/meerkat-core';
 import { duckdbExec } from '../duckdb-exec';
 
-export const ensureTableSchemasAlias = async (
-  tableSchemas: TableSchema[]
-): Promise<TableSchema[]> => {
+export interface EnsureTableSchemasAliasParams {
+  tableSchemas: TableSchema[];
+  /**
+   * Query whose member references drive which members are aliased. Members
+   * that the query does not reach are passed through untouched.
+   */
+  query: Query;
+}
+
+export const ensureTableSchemasAlias = async ({
+  tableSchemas,
+  query,
+}: EnsureTableSchemasAliasParams): Promise<TableSchema[]> => {
   return ensureTableSchemaAliasSql({
     tableSchemas,
+    query,
     ensureExpressionAlias: async ({ items }) => {
       const aliasedItems = await ensureColumnAliasBatch({
         items: items.map((item) => ({
@@ -17,8 +29,8 @@ export const ensureTableSchemasAlias = async (
           tableName: item.context.tableName,
           knownTableNames: item.context.knownTableNames,
         })),
-        executeQuery: (query) =>
-          duckdbExec<Record<string, string>[]>(query),
+        executeQuery: (queryString) =>
+          duckdbExec<Record<string, string>[]>(queryString),
       });
 
       return aliasedItems.map((item) => item.sql);
@@ -27,7 +39,10 @@ export const ensureTableSchemasAlias = async (
 };
 
 export const ensureTableSchemaAlias = () => {
-  return async (tableSchemas: TableSchema[]): Promise<TableSchema[]> => {
-    return ensureTableSchemasAlias(tableSchemas);
+  return async (
+    tableSchemas: TableSchema[],
+    query: Query
+  ): Promise<TableSchema[]> => {
+    return ensureTableSchemasAlias({ tableSchemas, query });
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26225,9 +26225,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "qs": ">=6.14.2",
     "vitest": "^4.0.18",
     "@tootallnate/once": ">=3.0.1",
-    "picomatch": ">=4.0.4"
+    "picomatch": ">=4.0.4",
+    "lodash-es": ">=4.18.1"
   }
 }


### PR DESCRIPTION
## Summary

`ensureTableSchemasAlias` was taking ~16.5s for tenants with ~8k fields even when the active query referenced only a handful of them:

```
"ensureTableSchemasAlias": "16569.6ms"
```

Every measure and dimension across every table schema was collected into one flat batch and pushed through `ensureColumnAliasBatch`, which does two DuckDB roundtrips (`parseExpressions` + `serializeExpressions`) that scale linearly with the batch size. Most of that work was wasted on members the query never touches.

## What changed

`ensureTableSchemaAliasSql` (meerkat-core) now takes the `Query` as a required arg and filters descriptors before batching. It walks:

- `query.measures`
- `query.dimensions`
- `query.order` keys
- `query.filters` (recursive `and` / `or` tree)

`joinPaths` is intentionally **excluded**: `left`/`right` are table names, not dotted member refs. The actual join SQL lives in `TableSchema.joins[].sql` which is already fully qualified and bypassed by the aliaser.

Members not referenced by the query are passed through untouched on the cloned schema — no parse/serialize roundtrip for them.

`meerkat-browser` and `meerkat-node` thread the new \`query\` arg through their thin wrappers.

## Expected impact

For a widget referencing ~20 members out of 8k, DuckDB sees 20 SQL strings per batch instead of 8000 — roughly a 400x reduction in parse/serialize work per call.

## BREAKING CHANGE

API surface change on \`@devrev/meerkat-core\`, \`@devrev/meerkat-browser\`, \`@devrev/meerkat-node\`:

- \`EnsureTableSchemaAliasSqlParams\` now requires \`query: Query\`.
- \`EnsureTableSchemasAliasParams\` now requires \`query: Query\`.
- The curried \`ensureTableSchemaAlias(connection)\` factory returns \`(tableSchemas, query) => ...\`.

All three packages bumped to \`0.0.128\`. A companion devrev-web PR updates the 4 call sites.

## Notes for reviewers

This PR currently includes the commit from #247 (\`fix: qualify struct field access to avoid binder ambiguity post-join\`) as a base, because it touches the same \`ensureTableSchemaAliasSql\` surface. Once #247 merges, this branch will rebase cleanly to only the perf commit. Please focus review on the top commit (\`perf: only alias schema members referenced by the query\`).

## Test plan

- [x] \`ensureTableSchemaAliasSql.spec.ts\` — 16/16 tests pass (11 existing + 5 new query-filtering cases):
  - skips members not referenced by the query
  - includes members referenced only by filters (including nested \`and\`/\`or\`)
  - includes members referenced only by \`order\`
  - ignores \`joinPaths\` entries because they reference table names
  - does not call the aliaser when no schema member is referenced
- [x] \`meerkat-browser\` and \`meerkat-node\` wrapper specs updated to pass \`query\` and assert it flows through.
- [ ] Load testing on a tenant with ~8k fields before rolling to prod (tracked in the devrev-web PR).

## Related

- DevRev: ISS-299745
- Depends on #247 landing first for a clean diff.