### PR TITLE
fix(joins-v2): correct UNNEST aliasing and support multi-hop array joins

### DIFF
--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-browser",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/meerkat-core/src/get-wrapped-base-query-with-projections/get-aliased-columns-from-filters.ts
+++ b/meerkat-core/src/get-wrapped-base-query-with-projections/get-aliased-columns-from-filters.ts
@@ -24,6 +24,8 @@ export const getDimensionProjection = ({
 
   const foundMember = findInDimensionSchema(measureWithoutTable, tableSchema);
   if (!foundMember || tableName !== tableSchema.name) {
+    // If the selected member is not found in the table schema or if it is already selected, continue.
+    // If the selected member is not from the current table, don't create an alias.
     return {
       sql: undefined,
       foundMember: undefined,

--- a/meerkat-core/src/get-wrapped-base-query-with-projections/get-aliased-columns-from-filters.ts
+++ b/meerkat-core/src/get-wrapped-base-query-with-projections/get-aliased-columns-from-filters.ts
@@ -24,8 +24,6 @@ export const getDimensionProjection = ({
 
   const foundMember = findInDimensionSchema(measureWithoutTable, tableSchema);
   if (!foundMember || tableName !== tableSchema.name) {
-    // If the selected member is not found in the table schema or if it is already selected, continue.
-    // If the selected member is not from the current table, don't create an alias.
     return {
       sql: undefined,
       foundMember: undefined,

--- a/meerkat-core/src/joins/index.ts
+++ b/meerkat-core/src/joins/index.ts
@@ -24,7 +24,4 @@ export {
   quoteIdentifierIfNeeded,
 } from './v1/joins';
 
-export {
-  createDirectedGraphV2,
-  generateSqlQueryV2,
-} from './v2/joins';
+export { createDirectedGraphV2, generateSqlQueryV2 } from './v2/joins';

--- a/meerkat-core/src/joins/v2/joins.spec.ts
+++ b/meerkat-core/src/joins/v2/joins.spec.ts
@@ -110,6 +110,72 @@ describe('joins-v2', () => {
     expect(sql).toContain('issues.__mk_u_owned_by_ids = admins.id');
   });
 
+  it('inlines dim.sql for composite-child synthetic array columns whose name is not a real column', () => {
+    // The synthetic dim `tags_$0_tag_id` is not a real column on the
+    // base table — only the parent `tags` struct array is. UNNEST must
+    // reference the dim's `sql` expression, not the synthetic name.
+    const schemas: TableSchema[] = [
+      {
+        name: 'parts',
+        sql: 'select * from parts',
+        dimensions: [
+          { name: 'id', sql: 'parts.id', type: 'string' },
+          {
+            name: 'tags_$0_tag_id',
+            sql: "json_extract_string(tags, '$[*].tag_id')",
+            type: 'string_array',
+          },
+        ],
+        measures: [],
+        joins: [],
+      },
+      scalar('tags'),
+    ];
+    const sqlMap = sqlMapOf(schemas);
+    const paths: StructuredJoin[][] = [
+      [
+        {
+          from: { table: 'parts', column: 'tags_$0_tag_id' },
+          to: { table: 'tags', column: 'id' },
+        },
+      ],
+    ];
+    const graph = createDirectedGraphV2(schemas, sqlMap, paths);
+    const sql = generateSqlQueryV2(paths, sqlMap, graph, schemas);
+
+    expect(sql).toContain(
+      "UNNEST(json_extract_string(tags, '$[*].tag_id')) AS __mk_u_tags_$0_tag_id"
+    );
+    expect(sql).toContain('parts.__mk_u_tags_$0_tag_id = tags.id');
+  });
+
+  it('wraps a multi-hop intermediate table when its from.column is array-typed', () => {
+    const schemas = [
+      scalar('tickets', ['id', 'part_id']),
+      withArrayCols('parts', ['id'], ['tag_ids']),
+      scalar('tags'),
+    ];
+    const sqlMap = sqlMapOf(schemas);
+    const paths: StructuredJoin[][] = [
+      [
+        {
+          from: { table: 'tickets', column: 'part_id' },
+          to: { table: 'parts', column: 'id' },
+        },
+        {
+          from: { table: 'parts', column: 'tag_ids' },
+          to: { table: 'tags', column: 'id' },
+        },
+      ],
+    ];
+    const graph = createDirectedGraphV2(schemas, sqlMap, paths);
+    const sql = generateSqlQueryV2(paths, sqlMap, graph, schemas);
+
+    expect(sql).toContain('tickets.part_id = parts.id');
+    expect(sql).toContain('UNNEST(tag_ids) AS __mk_u_tag_ids');
+    expect(sql).toContain('parts.__mk_u_tag_ids = tags.id');
+  });
+
   it('throws when both sides of an edge are array-typed', () => {
     const schemas = [
       withArrayCols('issues', ['id'], ['owned_by_ids']),

--- a/meerkat-core/src/joins/v2/joins.ts
+++ b/meerkat-core/src/joins/v2/joins.ts
@@ -78,6 +78,25 @@ const collectArrayJoinSources = (
  * DuckDB cannot hash-join on `CONTAINS(...)`/`list_contains`, so without
  * the wrap, array joins fall back to O(n × m) nested-loop scans.
  */
+/**
+ * The unnested column name used inside the wrapped subquery. Single source of
+ * truth for both the UNNEST projection and the predicate's left-hand side, so
+ * the names emitted in the SELECT list stay in lock-step with the names
+ * referenced in the ON clause.
+ */
+const getUnnestAlias = (column: string): string => `${UNNEST_ALIAS_PREFIX}${column}`;
+
+/**
+ * `<unnestAlias> AS <table.unnestAlias safe-key>` — re-aliases the unnested
+ * column under the canonical safe-key form so outer queries can reference it
+ * via the same `tableName____mk_u_<col>` identifier they use for any other
+ * member.
+ */
+const buildSafeKeyAliasProjection = (tableName: string, column: string): string => {
+  const unnestAlias = getUnnestAlias(column);
+  return `${unnestAlias} AS ${memberKeyToSafeKey(`${tableName}.${unnestAlias}`)}`;
+};
+
 const wrapTableSqlForArrayFrom = (
   baseSql: string,
   tableName: string,
@@ -89,14 +108,11 @@ const wrapTableSqlForArrayFrom = (
   const unnestProjections = cols
     .map((c) => {
       const expr = getArrayUnnestExpression(tableSchemas, tableName, c);
-      return `UNNEST(${expr}) AS ${UNNEST_ALIAS_PREFIX}${c}`;
+      return `UNNEST(${expr}) AS ${getUnnestAlias(c)}`;
     })
     .join(', ');
   const aliasProjections = cols
-    .map((c) => {
-      const unnestCol = `${UNNEST_ALIAS_PREFIX}${c}`;
-      return `${unnestCol} AS ${memberKeyToSafeKey(`${tableName}.${unnestCol}`)}`;
-    })
+    .map((c) => buildSafeKeyAliasProjection(tableName, c))
     .join(', ');
   const innerSql = `(SELECT *, ${unnestProjections} FROM (${baseSql}))`;
   return `(SELECT *, ${aliasProjections} FROM ${innerSql}) AS ${quoteIdentifierIfNeeded(
@@ -105,9 +121,7 @@ const wrapTableSqlForArrayFrom = (
 };
 
 const buildPredicate = (edge: StructuredJoin, fromIsArray: boolean): string => {
-  const leftColumn = fromIsArray
-    ? `${UNNEST_ALIAS_PREFIX}${edge.from.column}`
-    : edge.from.column;
+  const leftColumn = fromIsArray ? getUnnestAlias(edge.from.column) : edge.from.column;
   return `${edge.from.table}.${leftColumn} = ${edge.to.table}.${edge.to.column}`;
 };
 

--- a/meerkat-core/src/joins/v2/joins.ts
+++ b/meerkat-core/src/joins/v2/joins.ts
@@ -1,60 +1,114 @@
 import { getUsedTableSchema } from '../../get-used-table-schema/get-used-table-schema';
+import { memberKeyToSafeKey } from '../../member-formatters/member-key-to-safe-key';
 import { Graph, quoteIdentifierIfNeeded } from '../v1/joins';
 import { Query, StructuredJoin, TableSchema } from '../../types/cube-types';
 
 const UNNEST_ALIAS_PREFIX = '__mk_u_';
-const ARRAY_COLUMN_TYPES = new Set(['string_array', 'number_array']);
+const ARRAY_DIMENSION_TYPES = new Set(['string_array', 'number_array']);
+
+const findArrayMember = (
+  tableSchemas: TableSchema[],
+  table: string,
+  column: string
+) => {
+  const schema = tableSchemas.find((s) => s.name === table);
+  if (!schema) return undefined;
+  const member =
+    schema.dimensions.find((d) => d.name === column) ??
+    schema.measures.find((m) => m.name === column);
+  return member && ARRAY_DIMENSION_TYPES.has(member.type) ? member : undefined;
+};
 
 const isArrayColumn = (
   tableSchemas: TableSchema[],
   table: string,
   column: string
-): boolean => {
-  const t = tableSchemas.find((s) => s.name === table);
-  if (!t) return false;
-  const d = t.dimensions.find((x) => x.name === column);
-  if (d) return ARRAY_COLUMN_TYPES.has(d.type);
-  const m = t.measures.find((x) => x.name === column);
-  return m ? ARRAY_COLUMN_TYPES.has(m.type) : false;
-};
+): boolean => findArrayMember(tableSchemas, table, column) !== undefined;
 
-const buildPredicate = (edge: StructuredJoin, fromIsArray: boolean): string => {
-  const left = fromIsArray
-    ? `${edge.from.table}.${UNNEST_ALIAS_PREFIX}${edge.from.column}`
-    : `${edge.from.table}.${edge.from.column}`;
-  return `${left} = ${edge.to.table}.${edge.to.column}`;
+/**
+ * Returns the SQL expression to feed `UNNEST(...)` for an array column
+ * inside a `(SELECT *, UNNEST(<expr>) FROM (<baseSql>))` wrap. The
+ * subquery exposes the table's columns directly (via `SELECT *`) but
+ * the table alias is not yet in scope — so we strip a leading
+ * `${tableName}.` prefix from `dim.sql` if present. For composite-child
+ * synthetic dims (`tags_$0_tag_id`), `dim.sql` is the underlying
+ * expression like `json_extract_string(tags, '$[*].tag_id')` and works
+ * inside the wrap unchanged.
+ */
+const getArrayUnnestExpression = (
+  tableSchemas: TableSchema[],
+  table: string,
+  column: string
+): string => {
+  const member = findArrayMember(tableSchemas, table, column);
+  const sql = member?.sql ?? column;
+  return sql.startsWith(`${table}.`) ? sql.slice(table.length + 1) : sql;
 };
 
 /**
- * Wraps the base subquery with UNNEST projections for every array-typed
- * from-column referenced across the paths. DuckDB can't hash-join on
- * CONTAINS/list_contains, so without this wrap array joins fall back to
- * O(n × m).
+ * For each path edge whose `from.column` is array-typed, record the
+ * column under its source table. Multi-hop joins where the array column
+ * is on an intermediate table (e.g. `ticket -> part -> tag` with
+ * `part.tag_ids` as the array) require entries beyond the starting
+ * table so each hop's right side gets its own UNNEST wrap.
  */
-const wrapBaseSqlForArrayFrom = (
-  baseSql: string,
-  baseTable: string,
+const collectArrayJoinSources = (
   paths: StructuredJoin[][],
   tableSchemas: TableSchema[]
-): string => {
-  const cols = new Set<string>();
+): Map<string, Set<string>> => {
+  const result = new Map<string, Set<string>>();
   for (const path of paths) {
-    for (const edge of path) {
-      if (
-        edge.from.table === baseTable &&
-        isArrayColumn(tableSchemas, edge.from.table, edge.from.column)
-      ) {
-        cols.add(edge.from.column);
-      }
+    for (const { from } of path) {
+      if (!isArrayColumn(tableSchemas, from.table, from.column)) continue;
+      const cols = result.get(from.table) ?? new Set<string>();
+      cols.add(from.column);
+      result.set(from.table, cols);
     }
   }
-  if (cols.size === 0) return baseSql;
-  const projections = Array.from(cols)
-    .map((c) => `UNNEST(${c}) AS ${UNNEST_ALIAS_PREFIX}${c}`)
+  return result;
+};
+
+/**
+ * Wraps a table's subquery with UNNEST projections for each array column
+ * referenced as a join `from`. The unnested column is exposed under
+ * `__mk_u_<col>` for use in the ON clause and re-projected with its
+ * safe-key alias (`tableName____mk_u_<col>`) so the outer query can also
+ * reference it.
+ *
+ * DuckDB cannot hash-join on `CONTAINS(...)`/`list_contains`, so without
+ * the wrap, array joins fall back to O(n × m) nested-loop scans.
+ */
+const wrapTableSqlForArrayFrom = (
+  baseSql: string,
+  tableName: string,
+  arrayCols: Set<string> | undefined,
+  tableSchemas: TableSchema[]
+): string => {
+  if (!arrayCols || arrayCols.size === 0) return baseSql;
+  const cols = [...arrayCols];
+  const unnestProjections = cols
+    .map((c) => {
+      const expr = getArrayUnnestExpression(tableSchemas, tableName, c);
+      return `UNNEST(${expr}) AS ${UNNEST_ALIAS_PREFIX}${c}`;
+    })
     .join(', ');
-  return `(SELECT *, ${projections} FROM (${baseSql})) AS ${quoteIdentifierIfNeeded(
-    baseTable
+  const aliasProjections = cols
+    .map((c) => {
+      const unnestCol = `${UNNEST_ALIAS_PREFIX}${c}`;
+      return `${unnestCol} AS ${memberKeyToSafeKey(`${tableName}.${unnestCol}`)}`;
+    })
+    .join(', ');
+  const innerSql = `(SELECT *, ${unnestProjections} FROM (${baseSql}))`;
+  return `(SELECT *, ${aliasProjections} FROM ${innerSql}) AS ${quoteIdentifierIfNeeded(
+    tableName
   )}`;
+};
+
+const buildPredicate = (edge: StructuredJoin, fromIsArray: boolean): string => {
+  const leftColumn = fromIsArray
+    ? `${UNNEST_ALIAS_PREFIX}${edge.from.column}`
+    : edge.from.column;
+  return `${edge.from.table}.${leftColumn} = ${edge.to.table}.${edge.to.column}`;
 };
 
 export const createDirectedGraphV2 = (
@@ -84,8 +138,8 @@ export const createDirectedGraphV2 = (
       if (graph[from.table]?.[to.table]?.[from.column]) {
         throw new Error('An invalid path was detected.');
       }
-      if (!graph[from.table]) graph[from.table] = {};
-      if (!graph[from.table][to.table]) graph[from.table][to.table] = {};
+      graph[from.table] ??= {};
+      graph[from.table][to.table] ??= {};
       graph[from.table][to.table][from.column] = buildPredicate(edge, fromIsArray);
     }
   }
@@ -93,10 +147,11 @@ export const createDirectedGraphV2 = (
 };
 
 /**
- * Structurally identical to v1 `generateSqlQuery`. Only delta: when a
- * path's `from.column` is array-typed, the base subquery is wrapped with
- * UNNEST projections so the ON clause becomes a hash-joinable equi-join
- * (`base.__mk_u_col = right.col`) instead of a CONTAINS nested-loop.
+ * Builds the FROM clause for the combined table: the starting subquery
+ * left-joined against each downstream table along every path. v2 differs
+ * from v1 only in that any subquery whose source array column is joined
+ * gets UNNEST projections so the join becomes a hash-joinable equi-join
+ * (`base.__mk_u_col = right.col`) instead of a `CONTAINS(...)` scan.
  */
 export const generateSqlQueryV2 = (
   paths: StructuredJoin[][],
@@ -112,26 +167,27 @@ export const generateSqlQueryV2 = (
 
   const startingTable = paths[0][0]?.from.table;
   if (!startingTable) return '';
+  if (paths.some((p) => p[0]?.from.table !== startingTable)) {
+    throw new Error(
+      'Invalid path, starting node is not the same for all paths.'
+    );
+  }
 
-  let query = wrapBaseSqlForArrayFrom(
+  const arraySourcesByTable = collectArrayJoinSources(paths, tableSchemas);
+
+  let query = wrapTableSqlForArrayFrom(
     tableSchemaSqlMap[startingTable],
     startingTable,
-    paths,
+    arraySourcesByTable.get(startingTable),
     tableSchemas
   );
 
   const visited = new Map<string, StructuredJoin>();
 
-  for (let i = 0; i < paths.length; i++) {
-    if (paths[i][0]?.from.table !== startingTable) {
-      throw new Error(
-        'Invalid path, starting node is not the same for all paths.'
-      );
-    }
-    for (let j = 0; j < paths[i].length; j++) {
-      const edge = paths[i][j];
+  for (const path of paths) {
+    for (const edge of path) {
       const prev = visited.get(edge.to.table);
-      if (prev && prev.from.table === edge.from.table) continue;
+      if (prev?.from.table === edge.from.table) continue;
       if (prev) {
         throw new Error(
           `Path ambiguity, node ${edge.to.table} visited from different sources`
@@ -139,20 +195,25 @@ export const generateSqlQueryV2 = (
       }
       visited.set(edge.to.table, edge);
 
-      const quotedAlias = quoteIdentifierIfNeeded(edge.to.table);
-      query += ` LEFT JOIN (${
-        tableSchemaSqlMap[edge.to.table]
-      }) AS ${quotedAlias}  ON ${
-        directedGraph[edge.from.table][edge.to.table][edge.from.column]
-      }`;
+      const onClause =
+        directedGraph[edge.from.table][edge.to.table][edge.from.column];
+      const rightArrayCols = arraySourcesByTable.get(edge.to.table);
+      const rightSubquery = rightArrayCols?.size
+        ? wrapTableSqlForArrayFrom(
+            tableSchemaSqlMap[edge.to.table],
+            edge.to.table,
+            rightArrayCols,
+            tableSchemas
+          )
+        : `(${tableSchemaSqlMap[edge.to.table]}) AS ${quoteIdentifierIfNeeded(edge.to.table)}`;
+      query += ` LEFT JOIN ${rightSubquery}  ON ${onClause}`;
     }
   }
 
   return query;
 };
 
-/** Mirrors v1's `checkLoopInJoinPath` — detects cycles within a path. */
-const checkLoopInJoinPathV2 = (paths: StructuredJoin[][]): boolean => {
+const hasLoop = (paths: StructuredJoin[][]): boolean => {
   for (const path of paths) {
     const visited = new Set<string>();
     if (path[0]) visited.add(path[0].from.table);
@@ -170,38 +231,31 @@ export const getCombinedTableSchemaV2 = (
 ): TableSchema => {
   if (tableSchema.length === 1) return tableSchema[0];
 
-  const newTableSchema = cubeQuery.joinPathsV2?.length
+  // joinPathsV2 callers control which tables participate; everyone else
+  // gets the legacy auto-prune via getUsedTableSchema.
+  const activeTables = cubeQuery.joinPathsV2?.length
     ? tableSchema
     : getUsedTableSchema(tableSchema, cubeQuery);
-
-  if (newTableSchema.length === 1) return newTableSchema[0];
-
-  const tableSchemaSqlMap = newTableSchema.reduce(
-    (acc: { [key: string]: string }, s: TableSchema) => ({
-      ...acc,
-      [s.name]: s.sql,
-    }),
-    {}
-  );
+  if (activeTables.length === 1) return activeTables[0];
 
   const paths = cubeQuery.joinPathsV2 ?? [];
-  if (checkLoopInJoinPathV2(paths)) {
+  if (hasLoop(paths)) {
     throw new Error(
       `A loop was detected in the joins. ${JSON.stringify(paths)}`
     );
   }
-  const graph = createDirectedGraphV2(newTableSchema, tableSchemaSqlMap, paths);
-  const baseSql = generateSqlQueryV2(paths, tableSchemaSqlMap, graph, newTableSchema);
 
-  return newTableSchema.reduce(
-    (acc: TableSchema, s: TableSchema) => ({
-      name: 'MEERKAT_GENERATED_TABLE',
-      sql: baseSql,
-      measures: [...acc.measures, ...s.measures],
-      dimensions: [...acc.dimensions, ...s.dimensions],
-      joins: [],
-    }),
-    { name: '', sql: '', measures: [], dimensions: [], joins: [] }
+  const tableSchemaSqlMap = Object.fromEntries(
+    activeTables.map((s) => [s.name, s.sql])
   );
-};
+  const graph = createDirectedGraphV2(activeTables, tableSchemaSqlMap, paths);
+  const sql = generateSqlQueryV2(paths, tableSchemaSqlMap, graph, activeTables);
 
+  return {
+    name: 'MEERKAT_GENERATED_TABLE',
+    sql,
+    measures: activeTables.flatMap((s) => s.measures),
+    dimensions: activeTables.flatMap((s) => s.dimensions),
+    joins: [],
+  };
+};

--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-node/package.json
+++ b/meerkat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-node",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "dependencies": {
     "@devrev/meerkat-core": "*",
     "@swc/helpers": "~0.5.0",

--- a/meerkat-node/src/__tests__/joins-v2.spec.ts
+++ b/meerkat-node/src/__tests__/joins-v2.spec.ts
@@ -394,7 +394,7 @@ describe('Joins Tests (v2)', () => {
     expect(parsedOutput[1].orders__customer_id).toBe('2');
   });
 
-  describe('Array join with VALUES-list base SQL (ISS-304372)', () => {
+  describe('Array join with VALUES-list base SQL', () => {
     it('resolves __mk_u_ columns on a VALUES-list base table', async () => {
       const partSchema = {
         name: 'part',

--- a/meerkat-node/src/__tests__/joins-v2.spec.ts
+++ b/meerkat-node/src/__tests__/joins-v2.spec.ts
@@ -394,6 +394,141 @@ describe('Joins Tests (v2)', () => {
     expect(parsedOutput[1].orders__customer_id).toBe('2');
   });
 
+  describe('Array join with VALUES-list base SQL (ISS-304372)', () => {
+    it('resolves __mk_u_ columns on a VALUES-list base table', async () => {
+      const partSchema = {
+        name: 'part',
+        sql: `SELECT * FROM (VALUES ('p1', 'Part A', ['owner1', 'owner2']), ('p2', 'Part B', ['owner3'])) AS part(id, name, owned_by_ids)`,
+        measures: [],
+        dimensions: [
+          { name: 'id', sql: 'part.id', type: 'string' as const },
+          { name: 'name', sql: 'part.name', type: 'string' as const },
+          {
+            name: 'owned_by_ids',
+            sql: 'part.owned_by_ids',
+            type: 'string_array' as const,
+          },
+        ],
+        joins: [],
+      };
+      const devUserSchema = {
+        name: 'dev_user',
+        sql: `SELECT * FROM (VALUES ('owner1', 'Alice'), ('owner2', 'Bob'), ('owner3', 'Charlie')) AS dev_user(id, display_name)`,
+        measures: [],
+        dimensions: [
+          { name: 'id', sql: 'dev_user.id', type: 'string' as const },
+          {
+            name: 'display_name',
+            sql: 'dev_user.display_name',
+            type: 'string' as const,
+          },
+        ],
+        joins: [],
+      };
+
+      const query = {
+        measures: [],
+        joinPathsV2: [
+          [
+            {
+              from: { table: 'part', column: 'owned_by_ids' },
+              to: { table: 'dev_user', column: 'id' },
+            },
+          ],
+        ],
+        filters: [],
+        dimensions: ['part.name', 'dev_user.display_name'],
+        order: {
+          'part.name': 'asc',
+          'dev_user.display_name': 'asc',
+        },
+      };
+
+      const sql = await cubeQueryToSQL({
+        query,
+        tableSchemas: [partSchema, devUserSchema],
+      });
+
+      expect(sql).toContain('UNNEST');
+
+      const output = await duckdbExec(sql);
+      const parsedOutput = JSON.parse(JSON.stringify(output));
+
+      expect(parsedOutput).toHaveLength(3);
+      const pairs = parsedOutput.map(
+        (row: Record<string, unknown>) =>
+          `${row['part__name']}-${row['dev_user__display_name']}`
+      );
+      expect(pairs).toContain('Part A-Alice');
+      expect(pairs).toContain('Part A-Bob');
+      expect(pairs).toContain('Part B-Charlie');
+    });
+
+    it('supports filtering on the unnested dimension', async () => {
+      const partSchema = {
+        name: 'part',
+        sql: `SELECT * FROM (VALUES ('p1', 'Part A', ['owner1', 'owner2']), ('p2', 'Part B', ['owner3'])) AS part(id, name, owned_by_ids)`,
+        measures: [],
+        dimensions: [
+          { name: 'id', sql: 'part.id', type: 'string' as const },
+          { name: 'name', sql: 'part.name', type: 'string' as const },
+          {
+            name: 'owned_by_ids',
+            sql: 'part.owned_by_ids',
+            type: 'string_array' as const,
+          },
+        ],
+        joins: [],
+      };
+      const devUserSchema = {
+        name: 'dev_user',
+        sql: `SELECT * FROM (VALUES ('owner1', 'Alice'), ('owner2', 'Bob'), ('owner3', 'Charlie')) AS dev_user(id, display_name)`,
+        measures: [],
+        dimensions: [
+          { name: 'id', sql: 'dev_user.id', type: 'string' as const },
+          {
+            name: 'display_name',
+            sql: 'dev_user.display_name',
+            type: 'string' as const,
+          },
+        ],
+        joins: [],
+      };
+
+      const query = {
+        measures: [],
+        joinPathsV2: [
+          [
+            {
+              from: { table: 'part', column: 'owned_by_ids' },
+              to: { table: 'dev_user', column: 'id' },
+            },
+          ],
+        ],
+        filters: [
+          {
+            member: 'dev_user.display_name',
+            operator: 'equals',
+            values: ['Alice'],
+          },
+        ],
+        dimensions: ['part.name', 'dev_user.display_name'],
+      };
+
+      const sql = await cubeQueryToSQL({
+        query,
+        tableSchemas: [partSchema, devUserSchema],
+      });
+      const output = await duckdbExec(sql);
+      const parsedOutput = JSON.parse(JSON.stringify(output));
+
+      expect(parsedOutput).toHaveLength(1);
+      expect(parsedOutput[0]['part__name']).toBe('Part A');
+      expect(parsedOutput[0]['dev_user__display_name']).toBe('Alice');
+    });
+
+  });
+
   describe('Array Join Tests (UNNEST equi-join)', () => {
     it('Basic array join', async () => {
       const query = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express": "^4.21.2",
         "fake-indexeddb": "^5.0.1",
         "install": "^0.13.0",
-        "lodash": "^4.18.1",
+        "lodash": "4.18.1",
         "lodash.isnil": "^4.0.0",
         "loglevel": "^1.8.1",
         "next": "^16.2.6",
@@ -12242,13 +12242,6 @@
         }
       }
     },
-    "node_modules/@verdaccio/auth/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@verdaccio/commons-api": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@verdaccio/commons-api/-/commons-api-10.2.0.tgz",
@@ -12353,13 +12346,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@verdaccio/config/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@verdaccio/config/node_modules/minimatch": {
       "version": "7.4.6",
@@ -12510,13 +12496,6 @@
         }
       }
     },
-    "node_modules/@verdaccio/loaders/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@verdaccio/local-storage-legacy": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@verdaccio/local-storage-legacy/-/local-storage-legacy-11.0.2.tgz",
@@ -12565,13 +12544,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@verdaccio/local-storage-legacy/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@verdaccio/local-storage-legacy/node_modules/ms": {
       "version": "2.1.2",
@@ -12765,13 +12737,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/verdaccio"
       }
-    },
-    "node_modules/@verdaccio/logger-prettify/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@verdaccio/middleware": {
       "version": "8.0.0-next-8.1",
@@ -13001,13 +12966,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@verdaccio/middleware/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@verdaccio/middleware/node_modules/lru-cache": {
       "version": "7.18.3",
@@ -13267,13 +13225,6 @@
         }
       }
     },
-    "node_modules/@verdaccio/tarball/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@verdaccio/tarball/node_modules/tar-stream": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
@@ -13332,13 +13283,6 @@
         }
       }
     },
-    "node_modules/@verdaccio/url/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@verdaccio/utils": {
       "version": "7.0.1-next-8.1",
       "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-7.0.1-next-8.1.tgz",
@@ -13358,13 +13302,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/verdaccio"
       }
-    },
-    "node_modules/@verdaccio/utils/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@verdaccio/utils/node_modules/minimatch": {
       "version": "7.4.6",
@@ -15260,15 +15197,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -21847,6 +21775,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/getpass": {
@@ -38909,13 +38846,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/verdaccio/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/verdaccio/node_modules/lru-cache": {
       "version": "7.18.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express": "^4.21.2",
     "fake-indexeddb": "^5.0.1",
     "install": "^0.13.0",
-    "lodash": "^4.18.1",
+    "lodash": "4.18.1",
     "lodash.isnil": "^4.0.0",
     "loglevel": "^1.8.1",
     "next": "^16.2.6",
@@ -107,6 +107,8 @@
     "vitest": "^4.0.18",
     "@tootallnate/once": ">=3.0.1",
     "picomatch": ">=4.0.4",
-    "lodash-es": ">=4.18.1"
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
+    "basic-ftp": "5.3.1"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the `joinPathsV2` array-join machinery for two real-world cases the original implementation didn't handle: **multi-hop joins** where the array column lives on an intermediate table, and **composite-child synthetic dims** whose `name` is not a real column on the base table.

## Multi-hop UNNEST

DuckDB cannot hash-join on `CONTAINS(array, value)` — it falls back to O(n × m) nested loops. To get a real equi-join, meerkat UNNESTs the array column into a scalar before the join:

```sql
LEFT JOIN (
  SELECT *, UNNEST(tag_ids) AS __mk_u_tag_ids
  FROM (<part's base SQL>)
) AS part
ON part.__mk_u_tag_ids = tag.id
```

The original code applied this wrap **only to the starting table** of the join path. From `wrapBaseSqlForArrayFrom`:

```ts
for (const path of paths) {
  for (const edge of path) {
    if (edge.from.table === baseTable && isArrayColumn(...)) {
      cols.add(edge.from.column);
    }
  }
}
```

The `edge.from.table === baseTable` filter discarded array columns on every other table in the path.

For `ticket → part → tag` (where `part.tag_ids` is the array):

- Starting table: `ticket` — no array columns used as a join source
- `wrapBaseSqlForArrayFrom` returns the bare ticket SQL, no UNNEST
- The right side of the second hop is built as `LEFT JOIN (<part SQL>) AS part` — also no UNNEST
- The graph predicate `part.__mk_u_tag_ids = tag.id` references a column nothing produced
- **`Binder Error: column __mk_u_tag_ids not found`**

The fix replaces that filter with a new helper `collectArrayJoinSources` that builds a `Map<table, Set<column>>` spanning every hop. `generateSqlQueryV2` then applies the wrap per-table: the starting table still gets it if needed, and each LEFT JOIN's right side is conditionally wrapped if its table has array `from` columns.

## Composite-child synthetic array dims

For dims whose `name` is not a real column on the base table — e.g. `tags_$0_tag_id`, where the base table only has the parent `tags` struct array — `UNNEST(tags_$0_tag_id)` fails with `Binder Error: column not found`. The dim's `sql` field carries the extraction expression (`json_extract_string(tags, '$[*].tag_id')`), which is what UNNEST actually needs.

New helper `getArrayUnnestExpression` resolves the SQL expression to feed `UNNEST(...)`. It uses `dim.sql` when available and strips a leading `${tableName}.` prefix if present, since inside the wrap subquery the table alias is not yet in scope. Three shapes are handled:

| dim.name | dim.sql | UNNEST argument |
|---|---|---|
| `owned_by_ids` | `owned_by_ids` | `owned_by_ids` |
| `owned_by_ids` | `part.owned_by_ids` | `owned_by_ids` (prefix stripped) |
| `tags_$0_tag_id` | `json_extract_string(tags, '$[*].tag_id')` | the full expression |

## `__mk_u_*` is strictly internal

The original PR also added the synthetic `__mk_u_<col>` to the combined schema's dimensions list, so callers could query the unnested value directly. That leaked the internal aliasing scheme into the schema contract; no production caller used it.

Removed:
- The synthetic dim addition in `getCombinedTableSchemaV2`.
- The matching skip in `getDimensionProjection` (was defending against `__mk_u_*` showing up in the per-table phase; unreachable now).
- The `UNNEST_ALIAS_PREFIX` export from `joins/index`. The constant stays as a module-private inside `joins/v2`.
- Two integration tests that pre-declared `__mk_u_*` in the caller schema and queried it directly — both codified the leak as a contract.

Callers query the array dimension by its declared name (`part.tag_ids`); meerkat handles the UNNEST internally.

## Documentation

- DevRev Work item: ISS-304372

## Test plan

- [x] `npx nx test meerkat-core` — 540 passed.
- [x] New: `inlines dim.sql for composite-child synthetic array columns whose name is not a real column` — verifies UNNEST emits the json_extract expression.
- [x] New: `wraps a multi-hop intermediate table when its from.column is array-typed` — verifies `parts.__mk_u_tag_ids = tags.id` for `tickets → parts → tags`.
- [x] Existing array-join unit tests pass unchanged (single-hop UNNEST, shared-base UNNEST, array-array rejection).
- [x] meerkat-node integration coverage for VALUES-list base SQL and filtered array joins (callers query through declared dimensions).
- [x] Manually verified end-to-end against a `issue → part → tag → user` join where `part.tags_$0_tag_id` is the array column — error gone, query returns expected rows.