### PR TITLE
fix(meerkat-core): UNNEST expression retains table qualifier after ensureTableSchemasAlias rewrite

### DIFF
--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-browser",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/meerkat-core/src/joins/v2/joins.spec.ts
+++ b/meerkat-core/src/joins/v2/joins.spec.ts
@@ -176,6 +176,46 @@ describe('joins-v2', () => {
     expect(sql).toContain('parts.__mk_u_tag_ids = tags.id');
   });
 
+  it('strips table qualifier from CAST-wrapped array dim sql (ensureTableSchemasAlias output)', () => {
+    // After ensureTableSchemasAlias runs, the dim's sql becomes
+    // `CAST(issue.owned_by_ids AS VARCHAR[])` instead of plain `owned_by_ids`.
+    // The UNNEST wrap must strip the `issue.` qualifier since the inner
+    // subquery is unnamed at that scope.
+    const schemas: TableSchema[] = [
+      {
+        name: 'issue',
+        sql: 'SELECT CAST(issue.owned_by_ids AS VARCHAR[]) AS issue__owned_by_ids, issue.id AS issue__id, * FROM (select * from devrev.issue) AS issue',
+        dimensions: [
+          { name: 'id', sql: 'issue.id', type: 'string' },
+          {
+            name: 'owned_by_ids',
+            sql: 'CAST(issue.owned_by_ids AS VARCHAR[])',
+            type: 'string_array',
+          },
+        ],
+        measures: [],
+        joins: [],
+      },
+      scalar('users'),
+    ];
+    const sqlMap = sqlMapOf(schemas);
+    const paths: StructuredJoin[][] = [
+      [
+        {
+          from: { table: 'issue', column: 'owned_by_ids' },
+          to: { table: 'users', column: 'id' },
+        },
+      ],
+    ];
+    const graph = createDirectedGraphV2(schemas, sqlMap, paths);
+    const sql = generateSqlQueryV2(paths, sqlMap, graph, schemas);
+
+    // The UNNEST expression must NOT contain `issue.` since it's in an unnamed subquery scope
+    expect(sql).toContain('UNNEST(CAST(owned_by_ids AS VARCHAR[]))');
+    expect(sql).not.toMatch(/UNNEST\(CAST\(issue\./);
+    expect(sql).toContain('issue.__mk_u_owned_by_ids = users.id');
+  });
+
   it('throws when both sides of an edge are array-typed', () => {
     const schemas = [
       withArrayCols('issues', ['id'], ['owned_by_ids']),

--- a/meerkat-core/src/joins/v2/joins.ts
+++ b/meerkat-core/src/joins/v2/joins.ts
@@ -29,11 +29,10 @@ const isArrayColumn = (
  * Returns the SQL expression to feed `UNNEST(...)` for an array column
  * inside a `(SELECT *, UNNEST(<expr>) FROM (<baseSql>))` wrap. The
  * subquery exposes the table's columns directly (via `SELECT *`) but
- * the table alias is not yet in scope — so we strip a leading
- * `${tableName}.` prefix from `dim.sql` if present. For composite-child
- * synthetic dims (`tags_$0_tag_id`), `dim.sql` is the underlying
- * expression like `json_extract_string(tags, '$[*].tag_id')` and works
- * inside the wrap unchanged.
+ * the table alias is not yet in scope — so we strip all `${tableName}.`
+ * qualifiers from `dim.sql`. After `ensureTableSchemasAlias`, the SQL
+ * may be wrapped in expressions like `CAST(issue.col AS VARCHAR[])`,
+ * so a simple `startsWith` prefix check is not sufficient.
  */
 const getArrayUnnestExpression = (
   tableSchemas: TableSchema[],
@@ -42,7 +41,12 @@ const getArrayUnnestExpression = (
 ): string => {
   const member = findArrayMember(tableSchemas, table, column);
   const sql = member?.sql ?? column;
-  return sql.startsWith(`${table}.`) ? sql.slice(table.length + 1) : sql;
+  const tablePrefix = `${table}.`;
+  if (!sql.includes(tablePrefix)) return sql;
+  // Replace all occurrences of `table.` that appear as word-boundary
+  // qualified refs (not inside a string literal or as part of a longer name).
+  const escaped = table.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return sql.replace(new RegExp(`\\b${escaped}\\.`, 'g'), '');
 };
 
 /**

--- a/meerkat-node/package.json
+++ b/meerkat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-node",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "dependencies": {
     "@devrev/meerkat-core": "*",
     "@swc/helpers": "~0.5.0",


### PR DESCRIPTION
Issue: https://app.devrev.ai/devrev/issue/SURFF-1124

Problem: When a filter references the same array column used as a join key (e.g., filtering on issue.owned_by_ids while also joining on it), ensureTableSchemasAlias rewrites the dimension's SQL from owned_by_ids to CAST(issue.owned_by_ids AS VARCHAR[]). The v2 joins UNNEST wrapping then emits UNNEST(CAST(issue.owned_by_ids AS VARCHAR[])) inside a subquery scope where the table alias issue doesn't exist (DuckDB names it unnamed_subquery). The prefix-stripping logic only handled the trivial issue.col case, not table qualifiers embedded inside expressions like CAST(...).

One-liner for commit: Filters on array join columns caused "Referenced table not found" binder error because UNNEST inherited a table-qualified expression from the aliasing pass into an unnamed subquery scope.