### PR TITLE
fix(deps): bump ip-address>=10.1.1 for XSS (CVE-2026-42338)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23011,9 +23011,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "picomatch": ">=4.0.4",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "basic-ftp": "5.3.1"
+    "basic-ftp": "5.3.1",
+    "ip-address": ">=10.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `ip-address: ">=10.1.1"` override in `package.json` to resolve XSS vulnerability
- Fixes SNYK-JS-IPADDRESS-16636412 (CWE-79, CVSS 5.3, CVE-2026-42338)
- Transitive dependency via `puppeteer` → `socks` → `ip-address` and `duckdb` → `node-gyp` → `socks` → `ip-address`

## DevRev
work-item: ISS-302672

## Test plan
- [x] `npm ls ip-address` confirms upgrade to 10.2.0
- [ ] CI passes with updated lockfile
- [ ] Snyk scan no longer flags SNYK-JS-IPADDRESS-16636412

🤖 Generated with [Claude Code](https://claude.com/claude-code)