### PR TITLE
fix(ISS-317369): join notContains multiple values with AND not OR

### DIFF
--- a/meerkat-core/src/cube-filter-transformer/not-contains/contains.spec.ts
+++ b/meerkat-core/src/cube-filter-transformer/not-contains/contains.spec.ts
@@ -61,7 +61,7 @@ describe('Not Contains Transform Tests', () => {
       ).toEqual(expectedOutput);
     });
 
-    it('Should create an OR condition if there are multiple values', () => {
+    it('Should create an AND condition if there are multiple values', () => {
       const output = notContainsTransform(
         {
           member: 'country',
@@ -76,7 +76,7 @@ describe('Not Contains Transform Tests', () => {
         options
       ) as ConjunctionExpression;
       expect(output.class).toEqual(ExpressionClass.CONJUNCTION);
-      expect(output.type).toEqual(ExpressionType.CONJUNCTION_OR);
+      expect(output.type).toEqual(ExpressionType.CONJUNCTION_AND);
       expect(output.children.length).toEqual(3);
     });
   });
@@ -132,7 +132,7 @@ describe('Not Contains Transform Tests', () => {
       ).toEqual(expectedOutput);
     });
 
-    it('Should create an OR condition if there are multiple values', () => {
+    it('Should create an AND condition if there are multiple values', () => {
       const output = notContainsTransform(
         {
           member: 'country',
@@ -147,7 +147,7 @@ describe('Not Contains Transform Tests', () => {
         options
       ) as ConjunctionExpression;
       expect(output.class).toEqual(ExpressionClass.CONJUNCTION);
-      expect(output.type).toEqual(ExpressionType.CONJUNCTION_OR);
+      expect(output.type).toEqual(ExpressionType.CONJUNCTION_AND);
       expect(output.children.length).toEqual(3);
     });
   });

--- a/meerkat-core/src/cube-filter-transformer/not-contains/not-contains.ts
+++ b/meerkat-core/src/cube-filter-transformer/not-contains/not-contains.ts
@@ -9,8 +9,8 @@ import {
   CreateColumnRefOptions,
   valueBuilder,
 } from '../base-condition-builder/base-condition-builder';
+import { andDuckdbCondition } from '../and/and';
 import { CubeToParseExpressionTransform } from '../factory';
-import { orDuckdbCondition } from '../or/or';
 import { getSQLExpressionAST } from '../sql-expression/sql-expression-parser';
 
 export const notContainsDuckdbCondition = (
@@ -79,13 +79,17 @@ export const notContainsTransform: CubeToParseExpressionTransform = (
   }
 
   /**
-   * If there are multiple values, we need to create an OR condition
+   * If there are multiple values, we need to create an AND condition.
+   * "notContains: [a, b, c]" means the member contains none of the values,
+   * i.e. NOT LIKE a AND NOT LIKE b AND NOT LIKE c (De Morgan's law).
+   * Using OR here would always be true for any value that differs from a
+   * single entry, effectively disabling the filter.
    */
-  const orCondition = orDuckdbCondition();
+  const andCondition = andDuckdbCondition();
   values.forEach((value) => {
-    orCondition.children.push(
+    andCondition.children.push(
       notContainsDuckdbCondition(member, value, memberInfo, options)
     );
   });
-  return orCondition;
+  return andCondition;
 };

--- a/meerkat-node/src/__tests__/comprehensive/filters-string.test.ts
+++ b/meerkat-node/src/__tests__/comprehensive/filters-string.test.ts
@@ -194,13 +194,44 @@ describe('Comprehensive: String Filters', () => {
       
       const result = await duckdbExec(sql);
       const count = result[0]?.fact_all_types__count || 0;
-      
+
       // Should exclude 'high' (4/5 of data)
       expect(count).toBeGreaterThan(750000);
       expect(count).toBeLessThan(850000);
     });
+
+    // Regression: notContains with multiple values must join with AND, not OR.
+    // "none of [high, medium]" => NOT LIKE high AND NOT LIKE medium.
+    // With the previous OR bug the predicate was always true and the filter
+    // matched every row (~1M). Correct behaviour leaves low/critical/unknown
+    // (3/5 of data).
+    it('should filter string notContains with multiple values (none of)', async () => {
+      const query = {
+        measures: ['fact_all_types.count'],
+        filters: [
+          {
+            member: 'fact_all_types.priority',
+            operator: 'notContains',
+            values: ['high', 'medium'],
+          },
+        ],
+        dimensions: [],
+      };
+
+      const sql = await cubeQueryToSQL({
+        query,
+        tableSchemas: [FACT_ALL_TYPES_SCHEMA],
+      });
+
+      const result = await duckdbExec(sql);
+      const count = result[0]?.fact_all_types__count || 0;
+
+      // Should exclude both 'high' and 'medium' (leaving 3/5 of data).
+      expect(count).toBeGreaterThan(550000);
+      expect(count).toBeLessThan(650000);
+    });
   });
-  
+
   describe('IN Operator', () => {
     it('should filter string IN with multiple values', async () => {
       const query = {


### PR DESCRIPTION
## Summary

The `notContains` ("none of") filter transformer joined multiple values with a logical **OR** instead of **AND**. Because `notContains` emits a `NOT LIKE` (`!~~`) condition per value, OR makes the predicate a tautology — any row whose member differs from a single value already satisfies that disjunct, so the whole clause is always `TRUE` and the filter matches every row.

### Before (buggy)
```sql
WHERE ((ticket__subtype !~~ '%travel_approval%')
   OR  (ticket__subtype !~~ '%implementations%')
   OR  (ticket__subtype !~~ '%expense_approval%'))
```
Every row passes — a `travel_approval` subtype still satisfies the other two disjuncts.

### After (fixed)
```sql
WHERE ((ticket__subtype !~~ '%travel_approval%')
   AND (ticket__subtype !~~ '%implementations%')
   AND (ticket__subtype !~~ '%expense_approval%'))
```

"contains none of [a, b, c]" = `NOT LIKE a AND NOT LIKE b AND NOT LIKE c` (De Morgan's law). The multi-value branch now uses `andDuckdbCondition()`.

`notEquals` already delegates to `notIn` (NOT IN) for multiple values, so it is correct and unaffected.

## Changes
- `meerkat-core/.../not-contains/not-contains.ts` — multi-value branch builds a `CONJUNCTION_AND` instead of `CONJUNCTION_OR`
- `meerkat-core/.../not-contains/contains.spec.ts` — unit tests assert `CONJUNCTION_AND`
- `meerkat-node/.../comprehensive/filters-string.test.ts` — new DuckDB regression test for multi-value `notContains`

## DevRev
work-item: ISS-317369

## Test plan
- [x] meerkat-core unit tests (`not-contains`) — 6 passed
- [x] meerkat-node comprehensive suite — 739 passed (34 files)
- [x] New regression test: `notContains ['high','medium']` returns 3/5 of rows (not all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)