### PR TITLE
chore(release): bump package versions to 0.0.132 / 0.1.42

### DIFF
--- a/meerkat-browser/package.json
+++ b/meerkat-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-browser",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "dependencies": {
     "tslib": "^2.3.0",
     "@devrev/meerkat-core": "*",

--- a/meerkat-core/package.json
+++ b/meerkat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-core",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-node/package.json
+++ b/meerkat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-node",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "dependencies": {
     "@devrev/meerkat-core": "*",
     "@swc/helpers": "~0.5.0",


### PR DESCRIPTION
## Summary
- Bump `@devrev/meerkat-core` 0.0.131 -> 0.0.132
- Bump `@devrev/meerkat-node` 0.0.131 -> 0.0.132
- Bump `@devrev/meerkat-browser` 0.0.131 -> 0.0.132
- Bump `@devrev/meerkat-dbm` 0.1.41 -> 0.1.42

Releases the latest changes merged to main, including:
- fix(deps): resolve Snyk dependency vulnerabilities (#277)
- fix(ISS-317369): join notContains multiple values with AND not OR (#276)
- fix(tableSchema): pass correct tableSchema to avoid collision in measures (#275)
- fix(deps): bump ip-address>=10.1.1 for XSS vulnerability (CVE-2026-42338) (#268)
- fix(meerkat-core): UNNEST expression retains table qualifier after ensureTableSchemasAlias rewrite (#265)

## DevRev
work-item: ISS-317793

## Test plan
- [ ] CI build/test passes
- [ ] Publish workflow picks up the new versions after merge