### PR TITLE
feat(meerkat-dbm): add idle recycle policy alongside shutdown timer

### DIFF
--- a/meerkat-dbm/README.md
+++ b/meerkat-dbm/README.md
@@ -29,6 +29,7 @@ While `duckdb-wasm` is incredibly powerful, using it directly in a complex web a
 ### 🚀 Database Management
 
 - **Instance Management**: Automated lifecycle management for DuckDB instances.
+- **Idle Recycle & Shutdown**: Reclaim a worker's high-water memory after inactivity by recycling the engine (teardown + warm restart) before the final shutdown, with a consumer-supplied gate.
 - **Connection Pooling**: Efficient management of database connections.
 - **Query Queueing**: Intelligent scheduling of queries for sequential or parallel execution.
 - **Table Locking**: Ensures thread-safe table operations during concurrent access.
@@ -120,6 +121,14 @@ const dbm = new DBM({
   fileManager,
   onEvent: (event) => console.info('DBM Event:', event),
   options: {
+    // Optional intermediate "recycle" after 2s of inactivity: tear down the
+    // DuckDB instance and immediately re-instantiate it. Reclaims the worker's
+    // high-water memory (WASM linear memory only grows) while keeping the
+    // engine warm for the next query. Must be less than shutdownInactiveTime.
+    recycleInactiveTime: 2000,
+    // Optional gate consulted before each recycle. Return false to skip it
+    // (e.g. nothing worth reclaiming). Defaults to always-recycle when omitted.
+    shouldRecycle: () => true,
     // Automatically shut down the DuckDB instance after 5s of inactivity
     shutdownInactiveTime: 5000,
   },

--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -7,7 +7,7 @@ import {
 import { FileData, Table } from '../../types';
 import { DBM } from '../dbm';
 import { DBMConstructorOptions, TableConfig } from '../types';
-import { InstanceManager } from './mock';
+import { InstanceManager, mockDB } from './mock';
 
 export class MockFileManager implements FileManagerType {
   private fileBufferStore: Record<string, FileBufferStore> = {};
@@ -543,6 +543,76 @@ describe('DBM', () => {
       await queryPromise;
 
       expect(instanceManager.terminateDB).not.toBeCalled();
+    });
+
+    it('waits for an in-flight recycle before binding a connection (no dead connection)', async () => {
+      // Reproduces the teardown/getConnection race: a query that arrives while
+      // _recycle() is terminating the instance must NOT bind to the instance
+      // being destroyed. With the barrier it waits until the recycle finishes
+      // (terminate + warm re-instantiate), then connects to the fresh instance.
+      const events: string[] = [];
+
+      const instanceManager = new InstanceManager();
+      instanceManager.getDB = jest.fn(async () => {
+        events.push('getDB');
+        return mockDB as unknown as Awaited<
+          ReturnType<typeof instanceManager.getDB>
+        >;
+      });
+      // Slow terminate so the recycle is still mid-flight when the next query
+      // arrives — this is the window the barrier must cover.
+      instanceManager.terminateDB = jest.fn(
+        () =>
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              events.push('terminate-done');
+              resolve();
+            }, 150)
+          )
+      );
+      const connectSpy = jest.spyOn(mockDB, 'connect');
+
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+        options: { recycleInactiveTime: 100 },
+      });
+
+      await dbm.queryWithTables({ query: 'SELECT 1', tables });
+      connectSpy.mockClear();
+      connectSpy.mockImplementation(async () => {
+        events.push('connect');
+        return {
+          query: async (q: string) => [q],
+          cancelSent: async () => true,
+          close: async () => undefined,
+        } as unknown as Awaited<ReturnType<typeof mockDB.connect>>;
+      });
+
+      // Let the recycle fire; terminate is now in flight.
+      await new Promise((r) => setTimeout(r, 120));
+      expect(instanceManager.terminateDB).toBeCalledTimes(1);
+
+      // Query arrives mid-recycle. It must block on the barrier, not connect now.
+      const result = await dbm.queryWithTables({ query: 'SELECT 2', tables });
+
+      // Let the recycle's slow terminate + re-instantiate fully settle so the
+      // event ordering is complete before we assert on it.
+      await new Promise((r) => setTimeout(r, 250));
+
+      // The query succeeded against the warm instance...
+      expect(result).toEqual(['SELECT 2']);
+      // ...the teardown actually finished its terminate...
+      expect(events).toContain('terminate-done');
+      // ...and crucially the query connected only AFTER that terminate, i.e. it
+      // bound to the fresh instance, never the one being torn down.
+      expect(events.indexOf('connect')).toBeGreaterThan(
+        events.indexOf('terminate-done')
+      );
+
+      connectSpy.mockRestore();
     });
 
     it('throws when recycleInactiveTime is not less than shutdownInactiveTime', () => {

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -512,6 +512,47 @@ describe('DBM', () => {
       await new Promise((r) => setTimeout(r, 150));
       expect(instanceManager.terminateDB).toBeCalledTimes(2);
     });
+
+    it('does not recycle if a query starts executing while shouldRecycle awaits', async () => {
+      // A slow async gate widens the window between the idle re-check and the
+      // recycle. A query that arrives in that window must suppress the recycle
+      // so _recycle() never tears down a live connection mid-query.
+      let resolveGate: (value: boolean) => void = () => undefined;
+      const shouldRecycle = () =>
+        new Promise<boolean>((resolve) => {
+          resolveGate = resolve;
+        });
+
+      const { dbm, instanceManager } = buildDbm({
+        recycleInactiveTime: 100,
+        shouldRecycle,
+      });
+
+      await dbm.queryWithTables({ query: 'SELECT 1', tables });
+
+      // Let the recycle timer fire and enter the (pending) gate.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(instanceManager.terminateDB).not.toBeCalled();
+
+      // A new query arrives and begins executing while the gate is pending.
+      const queryPromise = dbm.queryWithTables({ query: 'SELECT 2', tables });
+
+      // Gate now resolves true — the post-await idle re-check must see the
+      // busy queue and skip the recycle.
+      resolveGate(true);
+      await queryPromise;
+
+      expect(instanceManager.terminateDB).not.toBeCalled();
+    });
+
+    it('throws when recycleInactiveTime is not less than shutdownInactiveTime', () => {
+      expect(() =>
+        buildDbm({ recycleInactiveTime: 300, shutdownInactiveTime: 300 })
+      ).toThrow(/recycleInactiveTime/);
+      expect(() =>
+        buildDbm({ recycleInactiveTime: 400, shutdownInactiveTime: 300 })
+      ).toThrow(/recycleInactiveTime/);
+    });
   });
 
   describe('cancel query execution', () => {

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -419,6 +419,101 @@ describe('DBM', () => {
     });
   });
 
+  describe('recycle the db test', () => {
+    const buildDbm = (
+      recycleOpts: {
+        recycleInactiveTime?: number;
+        shutdownInactiveTime?: number;
+        shouldRecycle?: () => boolean | Promise<boolean>;
+      },
+      onShutdown?: () => void
+    ) => {
+      const instanceManager = new InstanceManager();
+      instanceManager.terminateDB = jest.fn();
+      const getDBSpy = jest.spyOn(instanceManager, 'getDB');
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+        onDuckDBShutdown: onShutdown,
+        options: recycleOpts,
+      });
+      return { dbm, instanceManager, getDBSpy };
+    };
+
+    it('recycles (terminate + restart) at recycleInactiveTime, then shuts down at shutdownInactiveTime', async () => {
+      const onDuckDBShutdown = jest.fn();
+      const { dbm, instanceManager, getDBSpy } = buildDbm(
+        { recycleInactiveTime: 100, shutdownInactiveTime: 300 },
+        onDuckDBShutdown
+      );
+
+      await dbm.queryWithTables({ query: 'SELECT 1', tables });
+      getDBSpy.mockClear();
+
+      // Before recycle window: nothing fired.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(instanceManager.terminateDB).not.toBeCalled();
+
+      // After recycle window: terminate + restart (getDB) once.
+      await new Promise((r) => setTimeout(r, 100));
+      expect(instanceManager.terminateDB).toBeCalledTimes(1);
+      expect(getDBSpy).toBeCalledTimes(1); // eager restart
+
+      // After shutdown window: final shutdown terminates again, no restart.
+      await new Promise((r) => setTimeout(r, 200));
+      expect(instanceManager.terminateDB).toBeCalledTimes(2);
+      expect(getDBSpy).toBeCalledTimes(1);
+    });
+
+    it('skips the recycle when shouldRecycle returns false', async () => {
+      const { dbm, instanceManager, getDBSpy } = buildDbm({
+        recycleInactiveTime: 100,
+        shutdownInactiveTime: 300,
+        shouldRecycle: () => false,
+      });
+
+      await dbm.queryWithTables({ query: 'SELECT 1', tables });
+      getDBSpy.mockClear();
+
+      // Past the recycle window — gate said no, so no terminate yet.
+      await new Promise((r) => setTimeout(r, 180));
+      expect(instanceManager.terminateDB).not.toBeCalled();
+      expect(getDBSpy).not.toBeCalled();
+
+      // Final shutdown still fires.
+      await new Promise((r) => setTimeout(r, 180));
+      expect(instanceManager.terminateDB).toBeCalledTimes(1);
+    });
+
+    it('recycles at most once per idle period', async () => {
+      const { dbm, instanceManager } = buildDbm({
+        recycleInactiveTime: 100,
+        // No shutdown — isolate recycle behavior.
+      });
+
+      await dbm.queryWithTables({ query: 'SELECT 1', tables });
+
+      // Wait well past multiple recycle windows.
+      await new Promise((r) => setTimeout(r, 400));
+      expect(instanceManager.terminateDB).toBeCalledTimes(1);
+    });
+
+    it('re-arms the recycle after new activity', async () => {
+      const { dbm, instanceManager } = buildDbm({ recycleInactiveTime: 100 });
+
+      await dbm.queryWithTables({ query: 'SELECT 1', tables });
+      await new Promise((r) => setTimeout(r, 150));
+      expect(instanceManager.terminateDB).toBeCalledTimes(1);
+
+      // New query → idle period resets → recycle can fire again.
+      await dbm.queryWithTables({ query: 'SELECT 2', tables });
+      await new Promise((r) => setTimeout(r, 150));
+      expect(instanceManager.terminateDB).toBeCalledTimes(2);
+    });
+  });
+
   describe('cancel query execution', () => {
     it('should cancel the current executing query when abort is emitted', async () => {
       const abortController1 = new AbortController();

--- a/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
+++ b/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
@@ -29,6 +29,9 @@ export class DBMParallel extends TableLockManager {
   private iFrameRunnerManager: IFrameRunnerManager;
   private counter = 0;
   private terminateDBTimeout: NodeJS.Timeout | null = null;
+  private recycleDBTimeout: NodeJS.Timeout | null = null;
+  // Ensures the intermediate recycle fires at most once per idle period.
+  private recycledThisIdle = false;
   private activeNumberOfQueries = 0;
   private activeQueries: Map<
     string,
@@ -75,27 +78,74 @@ export class DBMParallel extends TableLockManager {
     await this.fileManager.onDBShutdownHandler();
   }
 
-  private _startShutdownInactiveTimer() {
-    if (!this.options?.shutdownInactiveTime) {
-      return;
+  /**
+   * Tear down the runners and immediately restart them — reclaims iframe/worker
+   * memory while keeping the engine warm for the next query. Mirrors _shutdown()
+   * cleanup, then re-starts the runners eagerly.
+   */
+  private async _recycle() {
+    this.logger.debug('Recycling the DB (idle teardown + restart)');
+    if (this.onDuckDBShutdown) {
+      this.onDuckDBShutdown();
     }
-    /**
-     * Clear the previous timer if any, it can happen if we try to shutdown the DB before the timer is complete after the queue is empty
-     */
+    this.iFrameRunnerManager.stopRunners();
+    await this.fileManager.onDBShutdownHandler();
+    // Re-create the runners eagerly so the next query hits warm iframes.
+    this.iFrameRunnerManager.startRunners();
+  }
+
+  /**
+   * Arm the idle timers when no queries are active. Two independent timers:
+   *  - recycleInactiveTime (optional, earlier): teardown + restart ONCE, gated
+   *    by shouldRecycle(). Reclaims memory without losing the warm engine.
+   *  - shutdownInactiveTime (later): full shutdown, no restart.
+   * Recycle is throttled to once per idle period via recycledThisIdle.
+   */
+  private _startShutdownInactiveTimer() {
+    this.recycledThisIdle = false;
+
+    if (this.recycleDBTimeout) {
+      clearTimeout(this.recycleDBTimeout);
+      this.recycleDBTimeout = null;
+    }
     if (this.terminateDBTimeout) {
       clearTimeout(this.terminateDBTimeout);
+      this.terminateDBTimeout = null;
     }
 
-    this.terminateDBTimeout = setTimeout(async () => {
-      /**
-       * Check if there is any query in the queue
-       */
-      if (this.activeNumberOfQueries > 0) {
-        this.logger.debug('Query queue is not empty, not shutting down the DB');
-        return;
-      }
-      await this._shutdown();
-    }, this.options.shutdownInactiveTime);
+    if (this.options?.recycleInactiveTime) {
+      this.recycleDBTimeout = setTimeout(async () => {
+        if (this.activeNumberOfQueries > 0 || this.recycledThisIdle) {
+          return;
+        }
+        const shouldRecycle = this.options?.shouldRecycle
+          ? await this.options.shouldRecycle()
+          : true;
+        if (!shouldRecycle) {
+          return;
+        }
+        if (this.activeNumberOfQueries > 0 || this.recycledThisIdle) {
+          return;
+        }
+        this.recycledThisIdle = true;
+        await this._recycle();
+      }, this.options.recycleInactiveTime);
+    }
+
+    if (this.options?.shutdownInactiveTime) {
+      this.terminateDBTimeout = setTimeout(async () => {
+        /**
+         * Check if there is any query in the queue
+         */
+        if (this.activeNumberOfQueries > 0) {
+          this.logger.debug(
+            'Query queue is not empty, not shutting down the DB'
+          );
+          return;
+        }
+        await this._shutdown();
+      }, this.options.shutdownInactiveTime);
+    }
   }
 
   private _signalListener(

--- a/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
+++ b/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
@@ -32,6 +32,10 @@ export class DBMParallel extends TableLockManager {
   private recycleDBTimeout: NodeJS.Timeout | null = null;
   // Ensures the intermediate recycle fires at most once per idle period.
   private recycledThisIdle = false;
+  // Set while a recycle/shutdown teardown is mid-flight. Queries wait on this
+  // so they never start runners that teardown is about to stop. Cleared when
+  // the teardown that set it completes.
+  private teardownInProgress: Promise<void> | null = null;
   private activeNumberOfQueries = 0;
   private activeQueries: Map<
     string,
@@ -86,6 +90,25 @@ export class DBMParallel extends TableLockManager {
     }
   }
 
+  /**
+   * Run a teardown (recycle/shutdown) body under a barrier so a query that
+   * arrives mid-teardown waits in queryWithTables instead of starting runners
+   * that teardown is about to stop. body()'s synchronous prefix runs before the
+   * barrier is recorded, but it has no synchronous-prefix await, so no query can
+   * interleave before the barrier is in place.
+   */
+  private _runTeardown(body: () => Promise<void>): Promise<void> {
+    const promise = body();
+    const barrier = promise.catch(() => undefined);
+    this.teardownInProgress = barrier;
+    barrier.then(() => {
+      if (this.teardownInProgress === barrier) {
+        this.teardownInProgress = null;
+      }
+    });
+    return promise;
+  }
+
   private async _shutdown() {
     // A shutdown supersedes any pending recycle — clear it so it can't fire
     // afterwards and restart the runners we are about to stop.
@@ -93,18 +116,20 @@ export class DBMParallel extends TableLockManager {
       clearTimeout(this.recycleDBTimeout);
       this.recycleDBTimeout = null;
     }
-    this.logger.debug('Shutting down the DB');
-    if (this.onDuckDBShutdown) {
-      this.onDuckDBShutdown();
-    }
-    /**
-     * This will remove all the iframes
-     */
-    this.iFrameRunnerManager.stopRunners();
-    /**
-     * This will remove all the file buffers from main thread
-     */
-    await this.fileManager.onDBShutdownHandler();
+    await this._runTeardown(async () => {
+      this.logger.debug('Shutting down the DB');
+      if (this.onDuckDBShutdown) {
+        this.onDuckDBShutdown();
+      }
+      /**
+       * This will remove all the iframes
+       */
+      this.iFrameRunnerManager.stopRunners();
+      /**
+       * This will remove all the file buffers from main thread
+       */
+      await this.fileManager.onDBShutdownHandler();
+    });
   }
 
   /**
@@ -113,14 +138,16 @@ export class DBMParallel extends TableLockManager {
    * cleanup, then re-starts the runners eagerly.
    */
   private async _recycle() {
-    this.logger.debug('Recycling the DB (idle teardown + restart)');
-    if (this.onDuckDBShutdown) {
-      this.onDuckDBShutdown();
-    }
-    this.iFrameRunnerManager.stopRunners();
-    await this.fileManager.onDBShutdownHandler();
-    // Re-create the runners eagerly so the next query hits warm iframes.
-    this.iFrameRunnerManager.startRunners();
+    await this._runTeardown(async () => {
+      this.logger.debug('Recycling the DB (idle teardown + restart)');
+      if (this.onDuckDBShutdown) {
+        this.onDuckDBShutdown();
+      }
+      this.iFrameRunnerManager.stopRunners();
+      await this.fileManager.onDBShutdownHandler();
+      // Re-create the runners eagerly so the next query hits warm iframes.
+      this.iFrameRunnerManager.startRunners();
+    });
   }
 
   /**
@@ -233,6 +260,14 @@ export class DBMParallel extends TableLockManager {
        * Tracking the number of active queries to shutdown the DB after inactivity
        */
       this.activeNumberOfQueries++;
+      /**
+       * Wait out any in-flight teardown so we don't start runners that recycle/
+       * shutdown is about to stop. Loop because a new teardown can begin while
+       * we awaited the previous one.
+       */
+      while (this.teardownInProgress) {
+        await this.teardownInProgress;
+      }
       /**
        * StartRunners will start the runners if they are not already running
        */

--- a/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
+++ b/meerkat-dbm/src/dbm/dbm-parallel/dbm-parallel.ts
@@ -61,9 +61,38 @@ export class DBMParallel extends TableLockManager {
     this.options = options;
     this.onDuckDBShutdown = onDuckDBShutdown;
     this.iFrameRunnerManager = iFrameRunnerManager;
+
+    this._validateIdleOptions();
+  }
+
+  /**
+   * Fail fast on a misconfigured idle policy. The recycle is the early action
+   * and the shutdown is the late one, so when both are set the recycle must
+   * fire strictly before the shutdown. Otherwise the shutdown's teardown would
+   * run first and a still-pending recycle would restart the runners we just
+   * stopped.
+   */
+  private _validateIdleOptions() {
+    const recycle = this.options?.recycleInactiveTime;
+    const shutdown = this.options?.shutdownInactiveTime;
+    if (
+      recycle !== undefined &&
+      shutdown !== undefined &&
+      recycle >= shutdown
+    ) {
+      throw new Error(
+        `Invalid idle options: recycleInactiveTime (${recycle}ms) must be less than shutdownInactiveTime (${shutdown}ms).`
+      );
+    }
   }
 
   private async _shutdown() {
+    // A shutdown supersedes any pending recycle — clear it so it can't fire
+    // afterwards and restart the runners we are about to stop.
+    if (this.recycleDBTimeout) {
+      clearTimeout(this.recycleDBTimeout);
+      this.recycleDBTimeout = null;
+    }
     this.logger.debug('Shutting down the DB');
     if (this.onDuckDBShutdown) {
       this.onDuckDBShutdown();

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -23,6 +23,9 @@ export class DBM extends TableLockManager {
   private onEvent?: (event: DBMEvent) => void;
   private options: DBMConstructorOptions['options'];
   private terminateDBTimeout: NodeJS.Timeout | null = null;
+  private recycleDBTimeout: NodeJS.Timeout | null = null;
+  // Ensures the intermediate recycle fires at most once per idle period.
+  private recycledThisIdle = false;
   private onDuckDBShutdown?: () => void;
   private onCreateConnection?: (
     connection: AsyncDuckDBConnection
@@ -72,26 +75,87 @@ export class DBM extends TableLockManager {
     await this.instanceManager.terminateDB();
   }
 
-  private _startShutdownInactiveTimer() {
-    if (!this.options?.shutdownInactiveTime) {
+  /**
+   * Tear down the engine and immediately re-instantiate it. Reclaims the
+   * worker's high-water memory while leaving a warm engine for the next query.
+   * Mirrors _shutdown()'s cleanup so the consumer's caches stay consistent,
+   * then eagerly re-acquires the DB so the cold instantiate is paid now (during
+   * idle) rather than on the next user-facing query.
+   */
+  private async _recycle() {
+    if (this.shutdownLock) {
       return;
     }
-    /**
-     * Clear the previous timer if any, it can happen if we try to shutdown the DB before the timer is complete after the queue is empty
-     */
+    if (this.connection) {
+      await this.connection.close();
+      this.connection = null;
+    }
+    this.logger.debug('Recycling the DB (idle teardown + restart)');
+    if (this.onDuckDBShutdown) {
+      this.onDuckDBShutdown();
+    }
+    await this.fileManager.onDBShutdownHandler();
+    await this.instanceManager.terminateDB();
+    // Re-instantiate eagerly so the next query hits a warm engine.
+    await this.instanceManager.getDB();
+  }
+
+  /**
+   * Arm the idle timers when the query queue drains. Two independent timers:
+   *  - recycleInactiveTime (optional, earlier): teardown + restart ONCE, gated
+   *    by shouldRecycle(). Reclaims memory without losing the warm engine.
+   *  - shutdownInactiveTime (later): full shutdown, no restart.
+   * Both re-arm on each queue-drain; recycle is throttled to once per idle
+   * period via recycledThisIdle (reset whenever new activity re-arms timers).
+   */
+  private _startShutdownInactiveTimer() {
+    this.recycledThisIdle = false;
+
+    if (this.recycleDBTimeout) {
+      clearTimeout(this.recycleDBTimeout);
+      this.recycleDBTimeout = null;
+    }
     if (this.terminateDBTimeout) {
       clearTimeout(this.terminateDBTimeout);
+      this.terminateDBTimeout = null;
     }
-    this.terminateDBTimeout = setTimeout(async () => {
-      /**
-       * Check if there is any query in the queue
-       */
-      if (this.queriesQueue.length > 0) {
-        this.logger.debug('Query queue is not empty, not shutting down the DB');
-        return;
-      }
-      await this._shutdown();
-    }, this.options.shutdownInactiveTime);
+
+    if (this.options?.recycleInactiveTime) {
+      this.recycleDBTimeout = setTimeout(async () => {
+        // Still idle?
+        if (this.queriesQueue.length > 0 || this.recycledThisIdle) {
+          return;
+        }
+        // Consult the consumer-supplied gate (defaults to always-recycle).
+        const shouldRecycle = this.options?.shouldRecycle
+          ? await this.options.shouldRecycle()
+          : true;
+        if (!shouldRecycle) {
+          return;
+        }
+        // Re-check idle after the (possibly async) gate resolved.
+        if (this.queriesQueue.length > 0 || this.recycledThisIdle) {
+          return;
+        }
+        this.recycledThisIdle = true;
+        await this._recycle();
+      }, this.options.recycleInactiveTime);
+    }
+
+    if (this.options?.shutdownInactiveTime) {
+      this.terminateDBTimeout = setTimeout(async () => {
+        /**
+         * Check if there is any query in the queue
+         */
+        if (this.queriesQueue.length > 0) {
+          this.logger.debug(
+            'Query queue is not empty, not shutting down the DB'
+          );
+          return;
+        }
+        await this._shutdown();
+      }, this.options.shutdownInactiveTime);
+    }
   }
 
   private _emitEvent(event: DBMEvent) {

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -53,6 +53,29 @@ export class DBM extends TableLockManager {
     this.instanceManager = instanceManager;
     this.onDuckDBShutdown = onDuckDBShutdown;
     this.onCreateConnection = onCreateConnection;
+
+    this._validateIdleOptions();
+  }
+
+  /**
+   * Fail fast on a misconfigured idle policy. The recycle is the early action
+   * and the shutdown is the late one, so when both are set the recycle must
+   * fire strictly before the shutdown. Otherwise the shutdown's terminateDB
+   * would run first and a still-pending recycle would re-instantiate the
+   * engine we just tore down.
+   */
+  private _validateIdleOptions() {
+    const recycle = this.options?.recycleInactiveTime;
+    const shutdown = this.options?.shutdownInactiveTime;
+    if (
+      recycle !== undefined &&
+      shutdown !== undefined &&
+      recycle >= shutdown
+    ) {
+      throw new Error(
+        `Invalid idle options: recycleInactiveTime (${recycle}ms) must be less than shutdownInactiveTime (${shutdown}ms).`
+      );
+    }
   }
 
   private async _shutdown() {
@@ -61,6 +84,13 @@ export class DBM extends TableLockManager {
      */
     if (this.shutdownLock) {
       return;
+    }
+
+    // A shutdown supersedes any pending recycle — clear it so it can't fire
+    // afterwards and re-instantiate the engine we are about to terminate.
+    if (this.recycleDBTimeout) {
+      clearTimeout(this.recycleDBTimeout);
+      this.recycleDBTimeout = null;
     }
 
     if (this.connection) {
@@ -82,6 +112,19 @@ export class DBM extends TableLockManager {
    * then eagerly re-acquires the DB so the cold instantiate is paid now (during
    * idle) rather than on the next user-facing query.
    */
+  /**
+   * True while any query is pending or executing. The queue is drained by
+   * _startQueryExecution shifting an item off before it runs, so a length of 0
+   * does not by itself mean idle — check the running flag and current item too.
+   */
+  private _isBusy() {
+    return (
+      this.queriesQueue.length > 0 ||
+      this.queryQueueRunning ||
+      this.currentQueryItem !== undefined
+    );
+  }
+
   private async _recycle() {
     if (this.shutdownLock) {
       return;
@@ -122,8 +165,9 @@ export class DBM extends TableLockManager {
 
     if (this.options?.recycleInactiveTime) {
       this.recycleDBTimeout = setTimeout(async () => {
-        // Still idle?
-        if (this.queriesQueue.length > 0 || this.recycledThisIdle) {
+        // Still idle? A running queue means a query was shifted off the queue
+        // and is executing, so queriesQueue.length alone is not enough.
+        if (this._isBusy() || this.recycledThisIdle) {
           return;
         }
         // Consult the consumer-supplied gate (defaults to always-recycle).
@@ -133,8 +177,9 @@ export class DBM extends TableLockManager {
         if (!shouldRecycle) {
           return;
         }
-        // Re-check idle after the (possibly async) gate resolved.
-        if (this.queriesQueue.length > 0 || this.recycledThisIdle) {
+        // Re-check idle after the (possibly async) gate resolved — a query may
+        // have arrived and started executing while shouldRecycle() awaited.
+        if (this._isBusy() || this.recycledThisIdle) {
           return;
         }
         this.recycledThisIdle = true;

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -26,6 +26,10 @@ export class DBM extends TableLockManager {
   private recycleDBTimeout: NodeJS.Timeout | null = null;
   // Ensures the intermediate recycle fires at most once per idle period.
   private recycledThisIdle = false;
+  // Set while a recycle/shutdown teardown is mid-flight. Queries acquiring a
+  // connection wait on this so they never bind to an instance that teardown is
+  // about to terminate. Cleared when the teardown that set it completes.
+  private teardownInProgress: Promise<void> | null = null;
   private onDuckDBShutdown?: () => void;
   private onCreateConnection?: (
     connection: AsyncDuckDBConnection
@@ -78,6 +82,30 @@ export class DBM extends TableLockManager {
     }
   }
 
+  /**
+   * Run a teardown (recycle/shutdown) body under a barrier so a query that
+   * arrives mid-teardown waits in _getConnection instead of binding to an
+   * instance that is about to be terminated. The body's synchronous prefix runs
+   * before this records the promise, but it contains no await, so no query can
+   * interleave before the barrier is in place.
+   */
+  private _runTeardown(body: () => Promise<void>): Promise<void> {
+    // body() runs synchronously up to its first await before returning, but it
+    // has no synchronous-prefix await that touches the connection, so recording
+    // the barrier here still happens before any query can interleave.
+    const promise = body();
+    const barrier = promise.catch(() => undefined);
+    this.teardownInProgress = barrier;
+    barrier.then(() => {
+      // Only clear if this teardown is still the active one — a later teardown
+      // may have replaced the barrier in the meantime.
+      if (this.teardownInProgress === barrier) {
+        this.teardownInProgress = null;
+      }
+    });
+    return promise;
+  }
+
   private async _shutdown() {
     /**
      * If the shutdown lock is true, then don't shutdown the DB
@@ -93,16 +121,18 @@ export class DBM extends TableLockManager {
       this.recycleDBTimeout = null;
     }
 
-    if (this.connection) {
-      await this.connection.close();
-      this.connection = null;
-    }
-    this.logger.debug('Shutting down the DB');
-    if (this.onDuckDBShutdown) {
-      this.onDuckDBShutdown();
-    }
-    await this.fileManager.onDBShutdownHandler();
-    await this.instanceManager.terminateDB();
+    await this._runTeardown(async () => {
+      if (this.connection) {
+        await this.connection.close();
+        this.connection = null;
+      }
+      this.logger.debug('Shutting down the DB');
+      if (this.onDuckDBShutdown) {
+        this.onDuckDBShutdown();
+      }
+      await this.fileManager.onDBShutdownHandler();
+      await this.instanceManager.terminateDB();
+    });
   }
 
   /**
@@ -129,18 +159,20 @@ export class DBM extends TableLockManager {
     if (this.shutdownLock) {
       return;
     }
-    if (this.connection) {
-      await this.connection.close();
-      this.connection = null;
-    }
-    this.logger.debug('Recycling the DB (idle teardown + restart)');
-    if (this.onDuckDBShutdown) {
-      this.onDuckDBShutdown();
-    }
-    await this.fileManager.onDBShutdownHandler();
-    await this.instanceManager.terminateDB();
-    // Re-instantiate eagerly so the next query hits a warm engine.
-    await this.instanceManager.getDB();
+    await this._runTeardown(async () => {
+      if (this.connection) {
+        await this.connection.close();
+        this.connection = null;
+      }
+      this.logger.debug('Recycling the DB (idle teardown + restart)');
+      if (this.onDuckDBShutdown) {
+        this.onDuckDBShutdown();
+      }
+      await this.fileManager.onDBShutdownHandler();
+      await this.instanceManager.terminateDB();
+      // Re-instantiate eagerly so the next query hits a warm engine.
+      await this.instanceManager.getDB();
+    });
   }
 
   /**
@@ -210,6 +242,12 @@ export class DBM extends TableLockManager {
   }
 
   private async _getConnection() {
+    // Wait out any in-flight teardown so we never bind a connection to an
+    // instance that recycle/shutdown is about to terminate. Loop because a new
+    // teardown can begin while we awaited the previous one.
+    while (this.teardownInProgress) {
+      await this.teardownInProgress;
+    }
     if (!this.connection) {
       const db = await this.instanceManager.getDB();
       this.connection = await db.connect();
@@ -225,6 +263,13 @@ export class DBM extends TableLockManager {
     tables: TableConfig[],
     options?: QueryOptions
   ) {
+    // Wait out any in-flight teardown before touching the DB. mountFileBuffer
+    // registers buffers into the instance via getDB(), so it must not run
+    // against an instance recycle/shutdown is about to terminate.
+    while (this.teardownInProgress) {
+      await this.teardownInProgress;
+    }
+
     /**
      * Load all the files into the database
      */

--- a/meerkat-dbm/src/dbm/types.ts
+++ b/meerkat-dbm/src/dbm/types.ts
@@ -48,6 +48,27 @@ export interface DBMConstructorOptions {
      * If not specified, the DB will not shutdown.
      */
     shutdownInactiveTime?: number;
+
+    /**
+     * @description
+     * Optional intermediate "recycle" before the final shutdown. After this much
+     * inactivity (in ms), the DB is torn down and immediately re-instantiated —
+     * reclaiming the worker's high-water memory while keeping the engine warm for
+     * the next query. Fires at most once per idle period. Requires
+     * `shutdownInactiveTime` to be set and larger than this value (the recycle is
+     * the early action; the shutdown is the late one). Gated by `shouldRecycle`.
+     * If not specified, no intermediate recycle happens.
+     */
+    recycleInactiveTime?: number;
+
+    /**
+     * @description
+     * Predicate consulted before an idle recycle. Return false to skip the recycle
+     * (e.g. when the engine holds no data worth reclaiming, so the recycle would
+     * only cost a needless re-instantiate). Only consulted when `recycleInactiveTime`
+     * is set. Defaults to always-recycle when omitted.
+     */
+    shouldRecycle?: () => boolean | Promise<boolean>;
   };
 
   /**


### PR DESCRIPTION
## What

Adds an optional intermediate **recycle** step to the DBM idle lifecycle, controlled by two new options on `DBMConstructorOptions.options`:

- **`recycleInactiveTime?: number`** — after this much inactivity, the engine is torn down and **immediately re-instantiated once** per idle period. Reclaims the worker's high-water memory (WASM linear memory only grows, never shrinks) while keeping a warm engine, so the next query avoids a cold WASM recompile.
- **`shouldRecycle?: () => boolean | Promise<boolean>`** — predicate gating the recycle. Return `false` to skip it (e.g. the engine holds no data worth reclaiming, so a recycle would only cost a needless re-instantiate). Defaults to always-recycle.

The existing `shutdownInactiveTime` is unchanged and fires later as the final shutdown (no restart). Both `DBM` and `DBMParallel` are covered — `DBMParallel`'s recycle tears down + restarts the iframe runners.

## Why

Consumers (devrev-web) currently face a tradeoff: a single `shutdownInactiveTime` either keeps the engine warm (holding memory) or kills it (forcing a ~cold-boot WASM recompile on the next interaction). The recycle step gives a middle ground — reclaim memory **and** stay warm — with a consumer-supplied gate so it only runs when worthwhile.

## Behavior

| Idle elapsed | Action |
|---|---|
| `recycleInactiveTime` | `shouldRecycle()` → if true: teardown + restart once; if false: skip |
| `shutdownInactiveTime` | full shutdown, no restart |

Recycle fires at most once per idle period; both timers re-arm on new query activity (queue drain).

## Tests

Added to `dbm.spec.ts`:
- recycles at `recycleInactiveTime`, then shuts down at `shutdownInactiveTime`
- skips recycle when `shouldRecycle` returns false (shutdown still fires)
- recycles at most once per idle period
- re-arms recycle after new activity

All 15 `dbm.spec` tests pass; full `meerkat-dbm` suite (93) green; build clean.

## Notes

Backward compatible — both new options are optional; omitting them preserves existing single-shutdown behavior exactly.

https://app.devrev.ai/devrev/issue/KERN-1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)