### PR TITLE
fix(meerkat-dbm): self-heal stale DuckDB worker in query()

### DIFF
--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -720,4 +720,57 @@ describe('DBM', () => {
       );
     });
   });
+
+  describe('stale worker self-heal', () => {
+    const buildDbm = (connectImpl: () => Promise<unknown>) => {
+      const instanceManager = new InstanceManager();
+      const getDBSpy = jest.spyOn(instanceManager, 'getDB').mockResolvedValue({
+        connect: connectImpl,
+      } as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>);
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+      });
+      return { dbm, getDBSpy };
+    };
+
+    it('re-acquires the engine and retries once when the worker was terminated', async () => {
+      const query = jest
+        .fn()
+        .mockRejectedValueOnce(
+          new Error('cannot send a message since the worker is not set!:RUN_QUERY')
+        )
+        .mockResolvedValueOnce(['ok']);
+      const close = jest.fn();
+      const { dbm, getDBSpy } = buildDbm(async () => ({ query, close }));
+
+      const result = await dbm.query('SELECT 1');
+
+      expect(result).toEqual(['ok']);
+      expect(query).toBeCalledTimes(2);
+      // Cold boot for the first connection + re-acquire for the retry.
+      expect(getDBSpy).toBeCalledTimes(2);
+    });
+
+    it('does not retry on an unrelated query error', async () => {
+      const query = jest.fn().mockRejectedValue(new Error('Parser Error: syntax'));
+      const { dbm, getDBSpy } = buildDbm(async () => ({ query, close: jest.fn() }));
+
+      await expect(dbm.query('SELECT 1')).rejects.toThrow('Parser Error: syntax');
+      expect(query).toBeCalledTimes(1);
+      expect(getDBSpy).toBeCalledTimes(1);
+    });
+
+    it('propagates the error when the retry also hits a stale worker', async () => {
+      const query = jest
+        .fn()
+        .mockRejectedValue(new Error('worker is not set'));
+      const { dbm } = buildDbm(async () => ({ query, close: jest.fn() }));
+
+      await expect(dbm.query('SELECT 1')).rejects.toThrow('worker is not set');
+      expect(query).toBeCalledTimes(2);
+    });
+  });
 });

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -523,6 +523,18 @@ export class DBM extends TableLockManager {
     return promise;
   }
 
+  /**
+   * The idle teardown terminates the underlying worker to reclaim memory. A
+   * query can race a completed teardown (or a shared engine terminated by
+   * another DBM), leaving a cached connection bound to a dead worker. duckdb-wasm
+   * surfaces this as "worker is not set". The teardown barrier in _getConnection
+   * only covers an in-flight teardown, not one that already finished.
+   */
+  private _isStaleWorkerError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes('worker is not set');
+  }
+
   async query(query: string): Promise<Table<any>> {
     /**
      * Get the connection or create a new one
@@ -532,7 +544,21 @@ export class DBM extends TableLockManager {
     /**
      * Execute the query
      */
-    return connection.query(query);
+    try {
+      return await connection.query(query);
+    } catch (error) {
+      if (!this._isStaleWorkerError(error)) {
+        throw error;
+      }
+      /**
+       * Drop the dead connection and re-acquire. _getConnection re-instantiates
+       * the engine via instanceManager.getDB(), so the retry runs against a
+       * fresh worker. Retried once — a second stale failure propagates.
+       */
+      this.connection = null;
+      const freshConnection = await this._getConnection();
+      return freshConnection.query(query);
+    }
   }
 
   /**


### PR DESCRIPTION
## What

`DBM.query()` now catches the duckdb-wasm `worker is not set` error, drops the dead cached connection, re-acquires the engine via `instanceManager.getDB()`, and retries the query once.

## Why

The idle lifecycle (`recycleInactiveTime` / `shutdownInactiveTime`, added in #283) terminates the underlying DuckDB worker to reclaim memory. A query can race a teardown that has **already completed** — or, when consumers share a single engine across multiple DBM instances, an engine terminated by a *different* DBM's idle timer — leaving `this.connection` bound to a dead worker. duckdb-wasm then throws:

```
cannot send a message since the worker is not set!:RUN_QUERY,<id>,SET TimeZone='UTC';
```

In devrev-web this surfaces as the vista / list-view error+retry screen after a tab is idle and the user switches back. Datadog RUM: hundreds of sessions, ~88% of error events fire on a backgrounded tab (idle teardown), ~12% foreground.

PR #283's `teardownInProgress` barrier only protects a query that arrives **while** a teardown is in flight — it makes the query wait and bind to the fresh instance. It does nothing for a query that hits a worker **after** the teardown finished, which is the dominant production case. This change closes that residual window at the connection layer, so every consumer benefits rather than each wrapping its own retry.

## Behavior

- Stale-worker error → null the connection, re-acquire (cold-boots the engine through the instance manager), retry once.
- Retried exactly once; a second stale failure propagates.
- Any non-stale error is rethrown immediately (no retry).

## Tests

Added to `dbm.spec.ts` (`stale worker self-heal`):
- re-acquires the engine and retries once when the worker was terminated (asserts `getDB` called twice)
- does not retry on an unrelated query error
- propagates the error when the retry also hits a stale worker

All 21 `dbm.spec` tests pass; `nx build` + `nx lint meerkat-dbm` clean (0 errors).

## Notes

- Bumps `@devrev/meerkat-dbm` 0.1.44 → 0.1.45.
- Follows #283. The devrev-web stopgap (devrev/devrev-web#52881) wraps the two query call sites with the same retry for immediate relief during cutover; once this ships and the version is bumped in devrev-web, that wrapper becomes redundant.
- Possible follow-up: expose a `dispose()` so consumers swapping DBM instances on a shared engine can stop orphaned idle timers (the other half of the shared-engine race).

work-item: ISS-334477
