### PR TITLE
fix(meerkat-dbm): detect stale worker by engine identity, not error message

### DIFF
--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -722,54 +722,99 @@ describe('DBM', () => {
   });
 
   describe('stale worker self-heal', () => {
-    const buildDbm = (connectImpl: () => Promise<unknown>) => {
+    // duckdb-wasm never throws when the worker is gone: AsyncDuckDB.postTask on
+    // a detached/terminated instance only console.errors and resolves
+    // undefined, so a stale cached connection would silently misbehave rather
+    // than reject. There is no exception to catch, so DBM must detect
+    // staleness itself before issuing the query.
+    const buildDb = (isDetached: boolean, connectImpl: () => Promise<unknown>) => ({
+      isDetached: () => isDetached,
+      connect: connectImpl,
+    });
+
+    it('reconnects when getDB() returns a different engine instance than the cached connection is bound to', async () => {
+      // terminateDB() + a fresh getDB() hands back a NEW AsyncDuckDB object.
+      // The new object itself reports isDetached() === false, so identity is
+      // the only signal that distinguishes it from the instance the cached
+      // connection actually belongs to.
       const instanceManager = new InstanceManager();
-      const getDBSpy = jest.spyOn(instanceManager, 'getDB').mockResolvedValue({
-        connect: connectImpl,
-      } as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>);
+      const staleConnect = jest.fn().mockResolvedValue({ query: jest.fn(), close: jest.fn() });
+      const freshQuery = jest.fn().mockResolvedValue(['ok']);
+      const freshConnect = jest.fn().mockResolvedValue({ query: freshQuery, close: jest.fn() });
+
+      const dbA = buildDb(false, staleConnect);
+      const dbB = buildDb(false, freshConnect);
+
+      const getDBSpy = jest
+        .spyOn(instanceManager, 'getDB')
+        .mockResolvedValueOnce(dbA as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>)
+        .mockResolvedValueOnce(dbB as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>);
+
       const dbm = new DBM({
         instanceManager,
         fileManager,
         logger: log,
         onEvent: () => undefined,
       });
-      return { dbm, getDBSpy };
-    };
 
-    it('re-acquires the engine and retries once when the worker was terminated', async () => {
-      const query = jest
-        .fn()
-        .mockRejectedValueOnce(
-          new Error('cannot send a message since the worker is not set!:RUN_QUERY')
-        )
-        .mockResolvedValueOnce(['ok']);
-      const close = jest.fn();
-      const { dbm, getDBSpy } = buildDbm(async () => ({ query, close }));
+      await dbm.query('SELECT 1');
+      expect(staleConnect).toBeCalledTimes(1);
 
-      const result = await dbm.query('SELECT 1');
+      const result = await dbm.query('SELECT 2');
 
       expect(result).toEqual(['ok']);
-      expect(query).toBeCalledTimes(2);
-      // Cold boot for the first connection + re-acquire for the retry.
+      expect(freshQuery).toBeCalledWith('SELECT 2');
+      expect(staleConnect).toBeCalledTimes(1);
+      expect(freshConnect).toBeCalledTimes(1);
       expect(getDBSpy).toBeCalledTimes(2);
     });
 
-    it('does not retry on an unrelated query error', async () => {
-      const query = jest.fn().mockRejectedValue(new Error('Parser Error: syntax'));
-      const { dbm, getDBSpy } = buildDbm(async () => ({ query, close: jest.fn() }));
+    it('reconnects when the same engine instance reports detached', async () => {
+      const instanceManager = new InstanceManager();
+      const query = jest.fn().mockResolvedValue(['ok']);
+      const connect = jest.fn().mockResolvedValue({ query, close: jest.fn() });
+      let isDetached = false;
+      const db = { isDetached: () => isDetached, connect };
 
-      await expect(dbm.query('SELECT 1')).rejects.toThrow('Parser Error: syntax');
-      expect(query).toBeCalledTimes(1);
-      expect(getDBSpy).toBeCalledTimes(1);
+      jest
+        .spyOn(instanceManager, 'getDB')
+        .mockResolvedValue(db as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>);
+
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+      });
+
+      await dbm.query('SELECT 1');
+      isDetached = true;
+      await dbm.query('SELECT 2');
+
+      expect(connect).toBeCalledTimes(2);
     });
 
-    it('propagates the error when the retry also hits a stale worker', async () => {
-      const query = jest
-        .fn()
-        .mockRejectedValue(new Error('worker is not set'));
-      const { dbm } = buildDbm(async () => ({ query, close: jest.fn() }));
+    it('reuses the cached connection when the engine is unchanged and not detached', async () => {
+      const instanceManager = new InstanceManager();
+      const query = jest.fn().mockResolvedValue(['ok']);
+      const connect = jest.fn().mockResolvedValue({ query, close: jest.fn() });
+      const db = buildDb(false, connect);
 
-      await expect(dbm.query('SELECT 1')).rejects.toThrow('worker is not set');
+      jest
+        .spyOn(instanceManager, 'getDB')
+        .mockResolvedValue(db as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>);
+
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+      });
+
+      await dbm.query('SELECT 1');
+      await dbm.query('SELECT 2');
+
+      expect(connect).toBeCalledTimes(1);
       expect(query).toBeCalledTimes(2);
     });
   });

--- a/meerkat-dbm/src/dbm/__test__/mock.ts
+++ b/meerkat-dbm/src/dbm/__test__/mock.ts
@@ -2,6 +2,7 @@ import { AsyncDuckDB } from '@duckdb/duckdb-wasm';
 import { InstanceManagerType } from '../instance-manager';
 
 export const mockDB = {
+  isDetached: () => false,
   registerFileBuffer: async (name: string, buffer: Uint8Array) => {
     return new Promise((resolve) => {
       setTimeout(() => {

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -1,4 +1,4 @@
-import { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
+import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
 import { Table } from 'apache-arrow/table';
 import uniqBy from 'lodash/uniqBy';
 import { v4 as uuidv4 } from 'uuid';
@@ -17,6 +17,12 @@ export class DBM extends TableLockManager {
   private fileManager: FileManagerType;
   private instanceManager: InstanceManagerType;
   private connection: AsyncDuckDBConnection | null = null;
+  // The engine instance `connection` was bound to. terminateDB() followed by a
+  // fresh getDB() hands back a NEW AsyncDuckDB object — the new object itself
+  // reports isDetached() === false, so that check alone can't tell a fresh
+  // engine apart from the one the cached connection actually belongs to.
+  // Comparing this reference is what catches the stale-connection case.
+  private connectionDb: AsyncDuckDB | null = null;
   private queriesQueue: QueryQueueItem[] = [];
 
   private logger: DBMLogger;
@@ -125,6 +131,7 @@ export class DBM extends TableLockManager {
       if (this.connection) {
         await this.connection.close();
         this.connection = null;
+        this.connectionDb = null;
       }
       this.logger.debug('Shutting down the DB');
       if (this.onDuckDBShutdown) {
@@ -163,6 +170,7 @@ export class DBM extends TableLockManager {
       if (this.connection) {
         await this.connection.close();
         this.connection = null;
+        this.connectionDb = null;
       }
       this.logger.debug('Recycling the DB (idle teardown + restart)');
       if (this.onDuckDBShutdown) {
@@ -248,9 +256,28 @@ export class DBM extends TableLockManager {
     while (this.teardownInProgress) {
       await this.teardownInProgress;
     }
+
+    const db = await this.instanceManager.getDB();
+
+    /**
+     * A query can race a teardown that already finished (or a shared engine
+     * terminated by another DBM instance). terminateDB() followed by getDB()
+     * hands back a NEW AsyncDuckDB object, so `db !== this.connectionDb` is the
+     * primary staleness signal — the fresh object itself always reports
+     * isDetached() === false, so that check alone can't catch this case.
+     * db.isDetached() stays as a secondary check for the same-instance
+     * detach case. duckdb-wasm never throws for either: AsyncDuckDB.postTask on
+     * a detached instance only console.errors and resolves undefined, so a
+     * stale cached connection would silently misbehave rather than reject.
+     */
+    if (this.connection && (db !== this.connectionDb || db.isDetached())) {
+      this.connection = null;
+      this.connectionDb = null;
+    }
+
     if (!this.connection) {
-      const db = await this.instanceManager.getDB();
       this.connection = await db.connect();
+      this.connectionDb = db;
       if (this.onCreateConnection) {
         await this.onCreateConnection(this.connection);
       }
@@ -523,18 +550,6 @@ export class DBM extends TableLockManager {
     return promise;
   }
 
-  /**
-   * The idle teardown terminates the underlying worker to reclaim memory. A
-   * query can race a completed teardown (or a shared engine terminated by
-   * another DBM), leaving a cached connection bound to a dead worker. duckdb-wasm
-   * surfaces this as "worker is not set". The teardown barrier in _getConnection
-   * only covers an in-flight teardown, not one that already finished.
-   */
-  private _isStaleWorkerError(error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error);
-    return message.includes('worker is not set');
-  }
-
   async query(query: string): Promise<Table<any>> {
     /**
      * Get the connection or create a new one
@@ -544,21 +559,7 @@ export class DBM extends TableLockManager {
     /**
      * Execute the query
      */
-    try {
-      return await connection.query(query);
-    } catch (error) {
-      if (!this._isStaleWorkerError(error)) {
-        throw error;
-      }
-      /**
-       * Drop the dead connection and re-acquire. _getConnection re-instantiates
-       * the engine via instanceManager.getDB(), so the retry runs against a
-       * fresh worker. Retried once — a second stale failure propagates.
-       */
-      this.connection = null;
-      const freshConnection = await this._getConnection();
-      return freshConnection.query(query);
-    }
+    return connection.query(query);
   }
 
   /**


### PR DESCRIPTION
## What

Corrects #287. `_getConnection()` now tracks the engine instance (`connectionDb`) a cached connection is bound to, and drops the connection when `instanceManager.getDB()` returns a **different instance** (by reference) or the same instance reports `isDetached()`. `query()`'s message-matching retry (which never fired) is removed — detection now happens before the query is issued, not after a catch that never triggers.

## Why #287 didn't work

Verified against the real `@duckdb/duckdb-wasm` source (not assumed):

```js
async postTask(e, r=[]) {
  if (!this._worker) {
    console.error("cannot send a message since the worker is not set!:" + e.type + "," + e.data);
    return;   // resolves undefined — never rejects
  }
  ...
}
```

The "worker is not set" string is only ever `console.error`'d, never thrown. `runQuery()` resolves `undefined`, and `AsyncDuckDBConnection.query()` then does `RecordBatchReader.from(undefined)`, which throws a generic `TypeError: Cannot read properties of undefined (reading 'peek')` — not an error containing "worker is not set" either way. #287's `_isStaleWorkerError()` message check in `query()`'s catch block had nothing to catch. Reproduced this directly with a minimal repro against the installed package.

## Why isDetached() alone (my first attempt at fixing this) also doesn't work

`instanceManager.terminateDB()` clears the underlying engine state, so the **next** `getDB()` call constructs a **brand-new `AsyncDuckDB` object** (confirmed against devrev-web's real `DuckDbInstanceManager`: `this.duckDBInstance = new AsyncDuckDB(logger, this.mainWorker)` on every cold boot). That new object always reports `isDetached() === false` — checking `isDetached()` on the object `getDB()` just returned tells you nothing about whether the **cached connection** (bound to the *previous*, now-dead object) is stale.

The actual staleness signal is identity: does the engine `getDB()` returns now differ from the engine the cached connection was created against? `isDetached()` remains a secondary check for the case where the *same* engine instance transitions to detached without a new object being minted.

## Tests

Rewrote `dbm.spec.ts`'s `stale worker self-heal` block (previous version tested the non-functional message-matching path):
- reconnects when `getDB()` returns a different engine instance than the cached connection is bound to
- reconnects when the same engine instance reports detached
- reuses the cached connection when the engine is unchanged and not detached

All 21 `dbm.spec` tests pass; full `meerkat-dbm` suite (113) green; `nx build` + `nx lint meerkat-dbm` clean (0 errors).

## Notes

- Bumps `@devrev/meerkat-dbm` 0.1.45 → 0.1.46.
- devrev-web (devrev/devrev-web#52881, already merged) will need a further version bump to 0.1.46 to pick this up — the previous bump to 0.1.45 shipped #287's non-functional fix.

work-item: ISS-334477