### PR TITLE
fix(meerkat-dbm): stop idle shutdown from terminating the worker mid-query

### DIFF
--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -721,56 +721,75 @@ describe('DBM', () => {
     });
   });
 
-  describe('stale worker self-heal', () => {
-    const buildDbm = (connectImpl: () => Promise<unknown>) => {
+  describe('shutdown does not fire while a query is in flight', () => {
+    it('does not terminate the worker when the shutdown timer elapses mid-query', async () => {
       const instanceManager = new InstanceManager();
-      const getDBSpy = jest.spyOn(instanceManager, 'getDB').mockResolvedValue({
-        connect: connectImpl,
-      } as unknown as Awaited<ReturnType<typeof instanceManager.getDB>>);
+      instanceManager.terminateDB = jest.fn();
+      const onDuckDBShutdown = jest.fn();
+
       const dbm = new DBM({
         instanceManager,
         fileManager,
         logger: log,
         onEvent: () => undefined,
+        onDuckDBShutdown,
+        options: {
+          shutdownInactiveTime: 100,
+        },
       });
-      return { dbm, getDBSpy };
-    };
 
-    it('re-acquires the engine and retries once when the worker was terminated', async () => {
-      const query = jest
-        .fn()
-        .mockRejectedValueOnce(
-          new Error('cannot send a message since the worker is not set!:RUN_QUERY')
-        )
-        .mockResolvedValueOnce(['ok']);
-      const close = jest.fn();
-      const { dbm, getDBSpy } = buildDbm(async () => ({ query, close }));
+      // preQuery holds the query in flight (currentQueryItem set, queue empty)
+      // well past shutdownInactiveTime, reproducing the mid-query window where
+      // the shutdown timer previously fired and killed the worker.
+      const result = await dbm.queryWithTables({
+        query: 'SELECT * FROM table1',
+        tables,
+        options: {
+          preQuery: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            // The shutdown timer has elapsed by now; it must have seen the
+            // in-flight query and skipped terminateDB.
+            expect(instanceManager.terminateDB).not.toBeCalled();
+          },
+        },
+      });
 
-      const result = await dbm.query('SELECT 1');
+      expect(result).toEqual(['SELECT * FROM table1']);
+      // Still not terminated immediately after the query resolves.
+      expect(instanceManager.terminateDB).not.toBeCalled();
 
-      expect(result).toEqual(['ok']);
-      expect(query).toBeCalledTimes(2);
-      // Cold boot for the first connection + re-acquire for the retry.
-      expect(getDBSpy).toBeCalledTimes(2);
+      // Once idle, the re-armed timer shuts down normally.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(instanceManager.terminateDB).toBeCalled();
+      expect(onDuckDBShutdown).toBeCalled();
     });
 
-    it('does not retry on an unrelated query error', async () => {
-      const query = jest.fn().mockRejectedValue(new Error('Parser Error: syntax'));
-      const { dbm, getDBSpy } = buildDbm(async () => ({ query, close: jest.fn() }));
+    it('cancels the pending shutdown timer when a new query starts', async () => {
+      const instanceManager = new InstanceManager();
+      instanceManager.terminateDB = jest.fn();
 
-      await expect(dbm.query('SELECT 1')).rejects.toThrow('Parser Error: syntax');
-      expect(query).toBeCalledTimes(1);
-      expect(getDBSpy).toBeCalledTimes(1);
-    });
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+        options: {
+          shutdownInactiveTime: 100,
+        },
+      });
 
-    it('propagates the error when the retry also hits a stale worker', async () => {
-      const query = jest
-        .fn()
-        .mockRejectedValue(new Error('worker is not set'));
-      const { dbm } = buildDbm(async () => ({ query, close: jest.fn() }));
+      // First query drains the queue and arms the shutdown timer.
+      await dbm.queryWithTables({ query: 'SELECT * FROM table1', tables });
 
-      await expect(dbm.query('SELECT 1')).rejects.toThrow('worker is not set');
-      expect(query).toBeCalledTimes(2);
+      // Start a second query before the timer elapses. Starting it must cancel
+      // the pending timer so it never fires against this query.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await dbm.queryWithTables({ query: 'SELECT * FROM table2', tables });
+
+      // The original timer's window has now fully passed; it must not have
+      // fired because starting the second query cleared it.
+      await new Promise((resolve) => setTimeout(resolve, 70));
+      expect(instanceManager.terminateDB).not.toBeCalled();
     });
   });
 });

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -221,13 +221,13 @@ export class DBM extends TableLockManager {
 
     if (this.options?.shutdownInactiveTime) {
       this.terminateDBTimeout = setTimeout(async () => {
-        /**
-         * Check if there is any query in the queue
-         */
-        if (this.queriesQueue.length > 0) {
-          this.logger.debug(
-            'Query queue is not empty, not shutting down the DB'
-          );
+        // A query that has been shifted off the queue is executing with
+        // queriesQueue.length === 0 (currentQueryItem set, queue running).
+        // Guarding on _isBusy() — same as the recycle timer — stops the
+        // shutdown from terminating the worker while a query is in flight,
+        // which otherwise kills the duckdb-wasm worker mid-postTask.
+        if (this._isBusy()) {
+          this.logger.debug('Query in flight, not shutting down the DB');
           return;
         }
         await this._shutdown();
@@ -443,6 +443,17 @@ export class DBM extends TableLockManager {
       this.logger.debug('Query queue is already running');
       return;
     }
+    // A query armed on the previous queue-drain keeps counting down through the
+    // start of this one. Cancel it now so the idle recycle/shutdown can't fire
+    // mid-query; both re-arm when the queue next drains (_stopQueryQueue).
+    if (this.recycleDBTimeout) {
+      clearTimeout(this.recycleDBTimeout);
+      this.recycleDBTimeout = null;
+    }
+    if (this.terminateDBTimeout) {
+      clearTimeout(this.terminateDBTimeout);
+      this.terminateDBTimeout = null;
+    }
     this.logger.debug('Starting query queue');
     this.queryQueueRunning = true;
     this._startQueryExecution();
@@ -523,18 +534,6 @@ export class DBM extends TableLockManager {
     return promise;
   }
 
-  /**
-   * The idle teardown terminates the underlying worker to reclaim memory. A
-   * query can race a completed teardown (or a shared engine terminated by
-   * another DBM), leaving a cached connection bound to a dead worker. duckdb-wasm
-   * surfaces this as "worker is not set". The teardown barrier in _getConnection
-   * only covers an in-flight teardown, not one that already finished.
-   */
-  private _isStaleWorkerError(error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error);
-    return message.includes('worker is not set');
-  }
-
   async query(query: string): Promise<Table<any>> {
     /**
      * Get the connection or create a new one
@@ -544,21 +543,7 @@ export class DBM extends TableLockManager {
     /**
      * Execute the query
      */
-    try {
-      return await connection.query(query);
-    } catch (error) {
-      if (!this._isStaleWorkerError(error)) {
-        throw error;
-      }
-      /**
-       * Drop the dead connection and re-acquire. _getConnection re-instantiates
-       * the engine via instanceManager.getDB(), so the retry runs against a
-       * fresh worker. Retried once — a second stale failure propagates.
-       */
-      this.connection = null;
-      const freshConnection = await this._getConnection();
-      return freshConnection.query(query);
-    }
+    return connection.query(query);
   }
 
   /**


### PR DESCRIPTION
## What

Two layered changes so an idle timer can't terminate the duckdb-wasm worker while a query is running:

1. **Cancel the pending recycle/shutdown timers when a query starts** (`_startQueryQueue`). They re-arm on the next queue drain. Primary fix — no idle timer is left pending during a query.
2. **Guard the shutdown timer callback on `_isBusy()`** (queue length OR queue running OR `currentQueryItem`), matching the recycle timer. Covers the event-loop edge where the timer callback was already queued before the new query cleared it.

Also removes the dead `_isStaleWorkerError` retry from #287.

## Why (root cause, verified against prod)

The `shutdownInactiveTime` timer is armed **only** when the queue drains (`_stopQueryQueue`), and was **never cleared when the next query started**. So a timer armed on the previous drain kept counting down through the start of the next query. `_startQueryExecution` **shifts the query off the queue before running it**, so during execution `queriesQueue.length === 0` while `currentQueryItem` is set and `queryQueueRunning` is true. The timer only checked `queriesQueue.length > 0`, so it treated the in-flight query as idle and called `_shutdown()` → `terminateDB()` **mid-query**.

duckdb-wasm does **not** throw for this — `AsyncDuckDB.postTask` on a detached worker only `console.error`s `"cannot send a message since the worker is not set!"` and resolves. Confirmed in prod RUM: every event is `source: console`, handling-stack `console error → postTask`. That's also why #287's catch-based self-heal never fired — the 0.1.45 build was empirically a no-op (fixed vs unfixed builds showed identical error rates).

## Tests

- `does not terminate the worker when the shutdown timer elapses mid-query` — query held in flight (slow `preQuery`) past `shutdownInactiveTime` must not trigger `terminateDB`, then shuts down normally once idle.
- `cancels the pending shutdown timer when a new query starts` — a second query started before a prior armed timer elapses must clear it so it never fires.

Full `meerkat-dbm` suite green (20 dbm.spec + all others); `nx build` + `nx lint` clean.

## Notes

- Bumps `@devrev/meerkat-dbm` 0.1.45 → 0.1.46. devrev-web bumps to pick it up.
- Scope: single-DBM race (the dominant production case). The cross-DBM shared-engine variant (multiple DBM types swapping one field) is out of scope here.
- Supersedes #287 (no-op) and #289 (isDetached — reconnects after the fact but doesn't prevent the mid-flight teardown). Both closed.

work-item: ISS-334477