### PR TITLE
fix(meerkat-dbm): treat held table locks as busy so idle shutdown can't kill mid-registration

### DIFF
--- a/meerkat-dbm/package.json
+++ b/meerkat-dbm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/meerkat-dbm",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.32.0",
     "apache-arrow": "^17.0.0",

--- a/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
+++ b/meerkat-dbm/src/dbm/__test__/dbm.spec.ts
@@ -791,5 +791,40 @@ describe('DBM', () => {
       await new Promise((resolve) => setTimeout(resolve, 70));
       expect(instanceManager.terminateDB).not.toBeCalled();
     });
+
+    it('does not terminate the worker while a table lock is held outside the query queue', async () => {
+      // File-buffer registration holds a table lock across its download and
+      // registers buffers directly on the worker — outside the query queue.
+      // The idle shutdown must treat a held lock as busy, else it terminates
+      // the worker mid-registration ("worker is not set").
+      const instanceManager = new InstanceManager();
+      instanceManager.terminateDB = jest.fn();
+
+      const dbm = new DBM({
+        instanceManager,
+        fileManager,
+        logger: log,
+        onEvent: () => undefined,
+        options: {
+          shutdownInactiveTime: 100,
+        },
+      });
+
+      // Arm the shutdown timer via a completed query (queue drains).
+      await dbm.queryWithTables({ query: 'SELECT * FROM table1', tables });
+
+      // Simulate registration: acquire a table lock and hold it across the
+      // shutdown window, as fetchAndRegisterChunksWithIndexedDb does.
+      await dbm.lockTables(['table1']);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Timer elapsed while the lock was held — must not have terminated.
+      expect(instanceManager.terminateDB).not.toBeCalled();
+
+      // Release the lock; the re-armed timer then shuts down once idle.
+      dbm.unlockTables(['table1']);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(instanceManager.terminateDB).toBeCalled();
+    });
   });
 });

--- a/meerkat-dbm/src/dbm/dbm.ts
+++ b/meerkat-dbm/src/dbm/dbm.ts
@@ -143,15 +143,20 @@ export class DBM extends TableLockManager {
    * idle) rather than on the next user-facing query.
    */
   /**
-   * True while any query is pending or executing. The queue is drained by
-   * _startQueryExecution shifting an item off before it runs, so a length of 0
-   * does not by itself mean idle — check the running flag and current item too.
+   * True while any work is in flight against the engine. Beyond the query queue
+   * (drained by _startQueryExecution shifting an item off before it runs, so a
+   * length of 0 does not by itself mean idle), this also covers work that
+   * touches the engine OUTSIDE the queue — notably file-buffer registration,
+   * which holds a table lock across its download and registers buffers directly
+   * on the worker. If the idle timer tore the worker down during that window,
+   * the registration's postTask would hit a dead worker ("worker is not set").
    */
   private _isBusy() {
     return (
       this.queriesQueue.length > 0 ||
       this.queryQueueRunning ||
-      this.currentQueryItem !== undefined
+      this.currentQueryItem !== undefined ||
+      this.hasActiveLocks()
     );
   }
 
@@ -222,12 +227,15 @@ export class DBM extends TableLockManager {
     if (this.options?.shutdownInactiveTime) {
       this.terminateDBTimeout = setTimeout(async () => {
         // A query that has been shifted off the queue is executing with
-        // queriesQueue.length === 0 (currentQueryItem set, queue running).
-        // Guarding on _isBusy() — same as the recycle timer — stops the
-        // shutdown from terminating the worker while a query is in flight,
-        // which otherwise kills the duckdb-wasm worker mid-postTask.
+        // queriesQueue.length === 0 (currentQueryItem set, queue running), and
+        // file registration holds a table lock outside the queue. Guarding on
+        // _isBusy() stops the shutdown from terminating the worker mid-flight.
+        // Re-arm (rather than drop) so the engine still idles down once the
+        // in-flight work — which may not end via a queue drain, e.g. a
+        // download-only registration — finishes.
         if (this._isBusy()) {
-          this.logger.debug('Query in flight, not shutting down the DB');
+          this.logger.debug('Work in flight, deferring shutdown');
+          this._startShutdownInactiveTimer();
           return;
         }
         await this._shutdown();
@@ -547,9 +555,20 @@ export class DBM extends TableLockManager {
   }
 
   /**
-   * Set the shutdown lock to prevent the DB from shutting down
+   * Set the shutdown lock to prevent the DB from shutting down while a caller
+   * holds it. Consumers hold the lock across multi-step operations that touch
+   * the engine outside the query queue (e.g. registering file buffers before
+   * querying), which _isBusy() cannot see.
+   *
+   * Releasing the lock re-arms the idle timers. Without this, a timer that
+   * fired while the lock was held returns early and is never rescheduled, so
+   * the engine would stay warm forever and never reclaim memory — defeating
+   * the whole idle-shutdown mechanism.
    */
   public async setShutdownLock(state: boolean) {
     this.shutdownLock = state;
+    if (!state && !this._isBusy()) {
+      this._startShutdownInactiveTimer();
+    }
   }
 }

--- a/meerkat-dbm/src/dbm/table-lock-manager.ts
+++ b/meerkat-dbm/src/dbm/table-lock-manager.ts
@@ -103,4 +103,16 @@ export class TableLockManager {
     const tableLock = this.tableLockRegistry[tableName];
     return tableLock ? tableLock.readersCount > 0 || tableLock.writer : false;
   }
+
+  /**
+   * True if any table currently holds a reader or writer lock. Used to detect
+   * work in flight outside the query queue — e.g. file-buffer registration
+   * holds a write lock across its (multi-second) download, during which the
+   * engine must not be torn down.
+   */
+  hasActiveLocks(): boolean {
+    return Object.values(this.tableLockRegistry).some(
+      (lock) => lock.readersCount > 0 || lock.writer
+    );
+  }
 }


### PR DESCRIPTION
## What

Follow-up to #290. `DBM._isBusy()` now also treats a held table lock as busy (via new `TableLockManager.hasActiveLocks()`), so the idle recycle/shutdown timers cannot terminate the worker while a file-buffer registration is in flight. Also: the shutdown timer re-arms when it defers on a busy state, and `setShutdownLock(false)` re-arms the idle timer.

## Why (root cause, audited)

#290 stopped the idle timers from firing while a query is in the **queue**. But list-view data loads register parquet buffers via `fetchAndRegisterChunksWithIndexedDb`, which:
- holds a `dbm.lockTables()` write lock across its multi-second download, and
- registers buffers on the worker **directly** — outside `queryWithTables`, so outside the query queue and the `teardownInProgress` barrier.

`_isBusy()` only looked at the queue, so during registration the engine looked idle. The recycle (30s) / shutdown timers then called `terminateDB()` mid-registration, and the next `registerFileBuffer` / `postTask` hit a dead worker → `"cannot send a message since the worker is not set!"` — the vista/list-view error (ISS-334477).

An audit of every worker-touching call site confirmed this is the gap for the lock-holding (INDEXDB) registration path, which is the confirmed failing path in production.

## Changes

- `TableLockManager.hasActiveLocks()` — any reader/writer lock currently held.
- `DBM._isBusy()` — also true when `hasActiveLocks()`.
- Shutdown timer re-arms when it defers due to busy state (so a lock-only op with no trailing query still lets the engine idle down afterward — no leaked warm engine).
- `setShutdownLock(false)` re-arms the idle timer (fixes a latent leak where a timer that fired while locked was never rescheduled).

## Tests

Added to `dbm.spec.ts`: a held table lock across the idle-shutdown window must not terminate the worker; shutdown still fires once the lock releases. Full `meerkat-dbm` suite green; `nx build` + `nx lint` clean.

## Notes

- Bumps `@devrev/meerkat-dbm` 0.1.46 → 0.1.47. devrev-web will bump to pick this up (with a regression test that reproduces the gap against the shipped package).
- Known adjacent gap (separate, not this customer's path): the MEMORY-DBM registration (`downloadAndRegisterFilesInDuckDB`) registers without a lock, so it isn't covered by `hasActiveLocks`. Tracked for a follow-up; Razorpay is on the non-parallel INDEXDB path, which this PR covers.

work-item: ISS-334477