### PR TITLE
chore(benchmarking): add DuckDB WASM memory POC route

### DIFF
--- a/benchmarking/src/app/app.tsx
+++ b/benchmarking/src/app/app.tsx
@@ -7,6 +7,7 @@ import { ParallelMemoryDBMProvider } from './dbm-context/parallel-memory-dbm-con
 import { RawDBMProvider } from './dbm-context/raw-dbm-context';
 import { FileLoader } from './file-loader/file-loader';
 import { NativeAppFileLoader } from './file-loader/native-app-file-loader';
+import { MemoryPoc } from './memory-poc/memory-poc';
 import { QueryBenchmarking } from './query-benchmarking/query-benchmarking';
 
 export function App() {
@@ -31,6 +32,9 @@ export function App() {
           </li>
           <li>
             <Link to="/native-dbm">Native Node DuckDB</Link>
+          </li>
+          <li>
+            <Link to="/memory-poc">Memory POC</Link>
           </li>
         </ul>
       </nav>
@@ -111,6 +115,15 @@ export function App() {
                   <QueryBenchmarking />
                 </NativeAppFileLoader>
               </NativeDBMProvider>
+            </div>
+          }
+        />
+        <Route
+          path="/memory-poc"
+          element={
+            <div>
+              <h1>Memory POC</h1>
+              <MemoryPoc />
             </div>
           }
         />

--- a/benchmarking/src/app/memory-poc/memory-poc.tsx
+++ b/benchmarking/src/app/memory-poc/memory-poc.tsx
@@ -1,0 +1,233 @@
+import { DBM, FileManagerType, MemoryDBFileManager } from '@devrev/meerkat-dbm';
+import axios from 'axios';
+import log from 'loglevel';
+import React, { useCallback, useRef, useState } from 'react';
+import { TAXI_FILE_URL } from '../file-loader/constants';
+import { useClassicEffect } from '../hooks/use-classic-effect';
+import { InstanceManager } from '../dbm-context/instance-manager';
+import { useAsyncDuckDB } from '../dbm-context/use-async-duckdb';
+import { generateViewQuery } from '../utils';
+import {
+  dropAllBuffers,
+  formatBytes,
+  MemorySnapshot,
+  POC_QUERIES,
+  resetEngine,
+  takeMemorySnapshot,
+  terminateEngine,
+} from './memory-probe';
+
+const TABLE_NAME = 'taxi';
+const FILE_NAME = 'taxi.parquet';
+
+export const MemoryPoc = () => {
+  const instanceManagerRef = useRef<InstanceManager>(new InstanceManager());
+  const fileManagerRef = useRef<FileManagerType | null>(null);
+  const dbmRef = useRef<DBM | null>(null);
+
+  const [status, setStatus] = useState('booting…');
+  const [loaded, setLoaded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [snapshots, setSnapshots] = useState<MemorySnapshot[]>([]);
+  const [queryMs, setQueryMs] = useState<Record<string, number>>({});
+  const iterationRef = useRef(0);
+  const startMsRef = useRef<number>(Date.now());
+  const loadStartedRef = useRef(false);
+
+  const dbState = useAsyncDuckDB();
+
+  const snap = useCallback(async (label: string) => {
+    if (!dbmRef.current) return;
+    iterationRef.current += 1;
+    const s = await takeMemorySnapshot(iterationRef.current, label, dbmRef.current, instanceManagerRef.current);
+    s.atMs = s.atMs - startMsRef.current;
+    setSnapshots((prev) => [...prev, s]);
+  }, []);
+
+  // Build the DBM once DuckDB is ready, then auto-load the parquet + view.
+  useClassicEffect(() => {
+    if (!dbState || loadStartedRef.current) {
+      return;
+    }
+    loadStartedRef.current = true;
+    fileManagerRef.current = new MemoryDBFileManager({
+      instanceManager: instanceManagerRef.current,
+      fetchTableFileBuffers: async () => [],
+    });
+    const dbm = new DBM({
+      instanceManager: instanceManagerRef.current,
+      fileManager: fileManagerRef.current,
+      logger: log,
+      onEvent: (event) => log.info(event),
+    });
+    dbmRef.current = dbm;
+
+    void (async () => {
+      try {
+        await snap('engine only (no data)');
+        setStatus('downloading 452 MB parquet…');
+        const res = await axios.get(TAXI_FILE_URL, { responseType: 'arraybuffer' });
+        const buffer = new Uint8Array(res.data);
+        setStatus(`registering ${formatBytes(buffer.byteLength)}…`);
+        await fileManagerRef.current!.registerFileBuffer({
+          tableName: TABLE_NAME,
+          fileName: FILE_NAME,
+          buffer,
+        });
+        await dbm.query(generateViewQuery(TABLE_NAME, [FILE_NAME]));
+        const countRes = await dbm.query(`SELECT count(*)::BIGINT AS n FROM ${TABLE_NAME}`);
+        const n = countRes.toArray()[0]?.toJSON()?.['n'];
+        setStatus(`loaded — ${formatBytes(buffer.byteLength)}, ${n ?? '?'} rows`);
+        setLoaded(true);
+        await snap('after load');
+      } catch (e) {
+        setStatus(`load failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })();
+  }, [dbState]);
+
+  const runQuery = useCallback(
+    async (q: { id: string; label: string; sql: string }) => {
+      if (!dbmRef.current) return;
+      setBusy(true);
+      try {
+        const start = performance.now();
+        await dbmRef.current.query(q.sql);
+        setQueryMs((prev) => ({ ...prev, [q.id]: performance.now() - start }));
+        await snap(q.label);
+      } catch (e) {
+        setStatus(`query "${q.label}" failed: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [snap],
+  );
+
+  const runAll = useCallback(async () => {
+    setBusy(true);
+    for (const q of POC_QUERIES) {
+      if (!dbmRef.current) break;
+      try {
+        const start = performance.now();
+        await dbmRef.current.query(q.sql);
+        setQueryMs((prev) => ({ ...prev, [q.id]: performance.now() - start }));
+        await snap(q.label);
+      } catch {
+        // keep going
+      }
+    }
+    setBusy(false);
+  }, [snap]);
+
+  const reclaim = useCallback(
+    async (mode: 'dropFiles' | 'reset' | 'terminate') => {
+      setBusy(true);
+      try {
+        if (mode === 'dropFiles') await dropAllBuffers(instanceManagerRef.current);
+        else if (mode === 'reset') await resetEngine(instanceManagerRef.current);
+        else await terminateEngine(instanceManagerRef.current);
+        setStatus(`${mode}() done`);
+        await snap(`after ${mode}()`);
+      } catch (e) {
+        setStatus(`${mode}() failed: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [snap],
+  );
+
+  const last = snapshots[snapshots.length - 1];
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 12 }}>
+      <div>
+        Loads the 452 MB NYC-taxi parquet via <code>registerFileBuffer</code>, creates a view, runs varied SQL, and
+        measures DuckDB memory + <b>measureUserAgentSpecificMemory()</b> (true per-context incl. WASM worker).
+      </div>
+      <div>
+        <b>status:</b> {status} {busy ? '(busy…)' : ''}
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <button disabled={!loaded || busy} onClick={() => void runAll()}>
+          Run all queries
+        </button>
+        {POC_QUERIES.map((q) => (
+          <button key={q.id} disabled={!loaded || busy} onClick={() => void runQuery(q)}>
+            {q.label}
+            {queryMs[q.id] != null ? ` — ${queryMs[q.id].toFixed(0)}ms` : ''}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <button disabled={busy} onClick={() => void reclaim('dropFiles')}>
+          dropFiles()
+        </button>
+        <button disabled={busy} onClick={() => void reclaim('reset')}>
+          reset()
+        </button>
+        <button disabled={busy} onClick={() => void reclaim('terminate')}>
+          terminate()
+        </button>
+        <button disabled={busy} onClick={() => void snap('manual')}>
+          Snapshot now
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
+        <span>samples: {snapshots.length}</span>
+        <span>DuckDB: {formatBytes(last?.duckDbUsedBytes ?? null)}</span>
+        <span>
+          globFiles: {formatBytes(last?.duckDbFileBytes ?? null)} ({last?.duckDbFileCount ?? 0})
+        </span>
+        <span>
+          <b>UA total (incl. WASM): {formatBytes(last?.uaTotalBytes ?? null)}</b>
+        </span>
+        <span>JS heap: {formatBytes(last?.jsHeapUsedBytes ?? null)}</span>
+      </div>
+
+      {last && Object.keys(last.uaByType).length > 0 ? (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, fontSize: 12 }}>
+          <b>UA by type:</b>
+          {Object.entries(last.uaByType)
+            .sort((a, b) => b[1] - a[1])
+            .map(([t, b]) => (
+              <span key={t}>
+                {t}: {formatBytes(b)}
+              </span>
+            ))}
+        </div>
+      ) : null}
+
+      <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left' }}>#</th>
+            <th style={{ textAlign: 'left' }}>t(s)</th>
+            <th style={{ textAlign: 'left' }}>event</th>
+            <th style={{ textAlign: 'left' }}>DuckDB</th>
+            <th style={{ textAlign: 'left' }}>globFiles</th>
+            <th style={{ textAlign: 'left' }}>UA total</th>
+            <th style={{ textAlign: 'left' }}>JS heap</th>
+          </tr>
+        </thead>
+        <tbody>
+          {snapshots.map((s) => (
+            <tr key={s.iteration}>
+              <td>{s.iteration}</td>
+              <td>{(s.atMs / 1000).toFixed(1)}</td>
+              <td>{s.label}</td>
+              <td>{formatBytes(s.duckDbUsedBytes)}</td>
+              <td>{formatBytes(s.duckDbFileBytes)}</td>
+              <td>{formatBytes(s.uaTotalBytes)}</td>
+              <td>{formatBytes(s.jsHeapUsedBytes)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/benchmarking/src/app/memory-poc/memory-probe.ts
+++ b/benchmarking/src/app/memory-poc/memory-probe.ts
@@ -1,0 +1,183 @@
+import { DBM, InstanceManagerType } from '@devrev/meerkat-dbm';
+
+/**
+ * One memory snapshot of the DuckDB WASM engine + the browser process. Because
+ * the benchmark app is cross-origin isolated (COOP/COEP set in vite.config), we
+ * can call measureUserAgentSpecificMemory() — which reports the TRUE per-context
+ * heap including the DuckDB WASM worker, the number performance.memory (main
+ * thread only) misses.
+ */
+export interface MemorySnapshot {
+  iteration: number;
+  atMs: number;
+  label: string;
+  /** DuckDB buffer-manager total, bytes — sum over duckdb_memory() tags. */
+  duckDbUsedBytes: number | null;
+  /** Per-tag DuckDB memory (PARQUET_READER, HASH_TABLE, ORDER_BY, WINDOW, …). */
+  duckDbByTag: Record<string, number>;
+  /** Attached file bytes from DuckDB's WASM FS (globFiles). The resident parquet
+   * footprint the recycle/shutdown reclaims. */
+  duckDbFileBytes: number;
+  duckDbFileCount: number;
+  /** measureUserAgentSpecificMemory() total across all contexts (incl. WASM
+   * worker) — the real browser-tab JS+WASM memory. null if unavailable. */
+  uaTotalBytes: number | null;
+  /** Per-context breakdown from measureUserAgentSpecificMemory (type → bytes). */
+  uaByType: Record<string, number>;
+  /** performance.memory main-thread JS heap (Chromium) — for comparison. */
+  jsHeapUsedBytes: number | null;
+}
+
+interface GlobbableDuckDb {
+  globFiles?: (path: string) => Promise<Array<{ fileName: string; fileSize?: number }>>;
+  dropFiles?: (names?: string[]) => Promise<unknown>;
+  reset?: () => Promise<unknown>;
+}
+
+const toBytes = (value: unknown): number | null => {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
+  const n = Number(String(value));
+  return Number.isFinite(n) ? n : null;
+};
+
+/** Cross-origin-isolated memory measurement — the true per-context heap. */
+const measureUaMemory = async (): Promise<{ total: number | null; byType: Record<string, number> }> => {
+  const measure = (performance as unknown as {
+    measureUserAgentSpecificMemory?: () => Promise<{
+      bytes: number;
+      breakdown: Array<{ bytes: number; types: string[] }>;
+    }>;
+  }).measureUserAgentSpecificMemory;
+
+  if (!measure || !(globalThis as unknown as { crossOriginIsolated?: boolean }).crossOriginIsolated) {
+    return { total: null, byType: {} };
+  }
+  try {
+    const result = await measure();
+    const byType: Record<string, number> = {};
+    for (const b of result.breakdown) {
+      const key = b.types.join('+') || 'unknown';
+      byType[key] = (byType[key] ?? 0) + b.bytes;
+    }
+    return { total: result.bytes, byType };
+  } catch {
+    return { total: null, byType: {} };
+  }
+};
+
+export const takeMemorySnapshot = async (
+  iteration: number,
+  label: string,
+  dbm: DBM,
+  instanceManager: InstanceManagerType,
+): Promise<MemorySnapshot> => {
+  const perfMemory = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory;
+
+  const snapshot: MemorySnapshot = {
+    iteration,
+    atMs: Date.now(),
+    label,
+    duckDbUsedBytes: null,
+    duckDbByTag: {},
+    duckDbFileBytes: 0,
+    duckDbFileCount: 0,
+    uaTotalBytes: null,
+    uaByType: {},
+    jsHeapUsedBytes: perfMemory?.usedJSHeapSize ?? null,
+  };
+
+  // duckdb_memory() per-tag breakdown via the DBM raw query.
+  try {
+    const res = await dbm.query(
+      'SELECT tag, (memory_usage_bytes + temporary_storage_bytes)::BIGINT AS used FROM duckdb_memory()',
+    );
+    const rows = res.toArray().map((r: { toJSON: () => Record<string, unknown> }) => r.toJSON());
+    let total = 0;
+    for (const row of rows) {
+      const tag = String(row['tag'] ?? '');
+      const used = Number(row['used'] ?? 0);
+      if (Number.isFinite(used) && used > 0) {
+        snapshot.duckDbByTag[tag] = used;
+        total += used;
+      }
+    }
+    snapshot.duckDbUsedBytes = total;
+  } catch {
+    // duckdb_memory() unsupported — leave null
+  }
+
+  // Attached files from the WASM FS (authoritative resident buffer set).
+  try {
+    const db = (await instanceManager.getDB()) as unknown as GlobbableDuckDb;
+    if (db.globFiles) {
+      const files = await db.globFiles('*');
+      snapshot.duckDbFileCount = files.length;
+      snapshot.duckDbFileBytes = files.reduce((sum, f) => sum + (f.fileSize ?? 0), 0);
+    }
+  } catch {
+    // leave 0
+  }
+
+  const ua = await measureUaMemory();
+  snapshot.uaTotalBytes = ua.total;
+  snapshot.uaByType = ua.byType;
+
+  return snapshot;
+};
+
+/** dropFiles() — free registered parquet buffers, keep engine warm. */
+export const dropAllBuffers = async (instanceManager: InstanceManagerType): Promise<void> => {
+  const db = (await instanceManager.getDB()) as unknown as GlobbableDuckDb;
+  await db.dropFiles?.();
+};
+
+/** reset() — reset the DB (drop catalog + buffers + cache), keep worker warm. */
+export const resetEngine = async (instanceManager: InstanceManagerType): Promise<void> => {
+  const db = (await instanceManager.getDB()) as unknown as GlobbableDuckDb;
+  await db.reset?.();
+};
+
+/** terminate — kill the worker (full shutdown; next query pays cold boot). */
+export const terminateEngine = async (instanceManager: InstanceManagerType): Promise<void> => {
+  await instanceManager.terminateDB();
+};
+
+export const formatBytes = (bytes: number | null): string => {
+  if (bytes === null) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+};
+
+/** Query variants over the taxi view — each stresses a different memory tag. */
+export const POC_QUERIES: Array<{ id: string; label: string; sql: string }> = [
+  { id: 'scan', label: 'scan + limit', sql: 'SELECT * FROM taxi LIMIT 1000' },
+  { id: 'count', label: 'count(*)', sql: 'SELECT count(*) AS n FROM taxi' },
+  {
+    id: 'groupby',
+    label: 'group by license',
+    sql: 'SELECT hvfhs_license_num, count(*) AS trips, avg(base_passenger_fare) AS avg_fare FROM taxi GROUP BY hvfhs_license_num ORDER BY trips DESC',
+  },
+  {
+    id: 'groupby-hi',
+    label: 'group by PU+DO (high card)',
+    sql: 'SELECT PULocationID, DOLocationID, count(*) AS n FROM taxi GROUP BY PULocationID, DOLocationID ORDER BY n DESC LIMIT 500',
+  },
+  {
+    id: 'orderby',
+    label: 'order by fare (full sort)',
+    sql: 'SELECT hvfhs_license_num, base_passenger_fare FROM taxi ORDER BY base_passenger_fare DESC LIMIT 1000',
+  },
+  {
+    id: 'window',
+    label: 'window: rank per license',
+    sql: 'SELECT hvfhs_license_num, base_passenger_fare, row_number() OVER (PARTITION BY hvfhs_license_num ORDER BY base_passenger_fare DESC) AS rnk FROM taxi QUALIFY rnk <= 100',
+  },
+];


### PR DESCRIPTION
## What

Adds a `/memory-poc` route to the benchmarking app to characterize DuckDB-wasm memory behavior — driven by a real question: **why does the browser tab hold ~2GB after list queries and only release it on engine shutdown?**

It loads the 452 MB NYC-taxi parquet via `registerFileBuffer`, creates a view, runs varied SQL, and snapshots memory after each step.

## Measures 3 layers

- **`duckdb_memory()`** per-tag — buffer-manager working set (PARQUET_READER, HASH_TABLE, ORDER_BY, WINDOW)
- **`globFiles()`** — resident registered parquet buffer bytes, straight from the WASM FS
- **`measureUserAgentSpecificMemory()`** — true per-context total **including the DuckDB WASM worker** (works because the benchmark app is cross-origin isolated via COOP/COEP)

Plus reclaim buttons: `dropFiles()`, `reset()`, `terminate()`.

## Key finding

**`WebAssembly.Memory` only grows, never shrinks** (no `shrink()` in the spec).

- Loading data + running queries grows the WASM linear memory to a high-water mark (250MB → ~2GB in Activity Monitor).
- `dropFiles()` / `reset()` free the bytes **inside** DuckDB's allocator — `duckdb_memory()` and `globFiles()` drop to 0, and the space is reusable for the next load — **but the WASM buffer stays at its high-water size**, so the browser-tab / OS footprint does **not** drop.
- **Only `terminate()`** (kill the worker → WASM `Memory` ArrayBuffer deallocated) returns the memory to the OS — at the cost of a ~5s WASM recompile on the next query.

**Implication:** the idle `terminate()` shutdown is the *only* lever that returns RAM to the browser. `dropFiles()`/`reset()` help intra-WASM reuse (cap re-growth on subsequent loads) but cannot reduce tab memory. To keep the peak low, the practical lever is `dropFile()` **per table right after its query** so N tables don't stack N×buffer.

## How to run

```
nx serve benchmarking-app   # → http://localhost:4204/memory-poc
```

Auto-loads the parquet, then use the query + reclaim buttons; watch the snapshot table (DuckDB / globFiles / UA-total / JS-heap) and Activity Monitor.

## Notes

- POC / diagnostic only — not wired into any product path.
- `meerkat-dbm/group.ts` and `package-lock.json` in the working tree are unrelated and intentionally excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
